### PR TITLE
Fix invalid variable usage in EditableField component

### DIFF
--- a/dc20-creature-creator/src/components/EditableField.jsx
+++ b/dc20-creature-creator/src/components/EditableField.jsx
@@ -56,7 +56,7 @@ const EditableField = ({
             if (isNaN(numValue)) {
                 // What to do if user types "abc" for a number?
                 // Option A: Revert to original 'value' prop
-                finalValueToSave = value;
+                finalValue = value;
                 // Option B: Save a default like 0
                 // finalValueToSave = 0;
                 // Option C: Don't save, keep editing (more complex UI)


### PR DESCRIPTION
## Summary
- fix typo in `EditableField` where a non-existent variable was used

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68567dd524c48331941298197841f237