### PR TITLE
Remove unused 'where' import

### DIFF
--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
@@ -6,7 +6,7 @@ import InputPanel from '../components/InputPanel';
 import StatBlockPanel from '../components/StatBlockPanel';
 import { calculateCreatureStats } from '../utils/calculateStats';
 import { db } from '../firebase';
-import { collection, query, where, getDocs, orderBy, addDoc, serverTimestamp } from 'firebase/firestore';
+import { collection, query, getDocs, orderBy, addDoc, serverTimestamp } from 'firebase/firestore';
 
 const CreatureCreatorPage = ({ currentUser }) => {
   // --- State for Creature Inputs ---


### PR DESCRIPTION
## Summary
- clean up unused `where` import from Firestore

## Testing
- `npm test`
- `npm run lint` *(fails: 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6857c2781a848331b9ea64d5ea170c3c