### PR TITLE
Fix number input parsing

### DIFF
--- a/dc20-creature-creator/src/components/FeatureCreationForm.jsx
+++ b/dc20-creature-creator/src/components/FeatureCreationForm.jsx
@@ -88,9 +88,9 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
 
     const constructFeatureData = () => {
         let costStringParts = [];
-        const numAP = parseInt(costAP) || 0;
-        const numMP = parseInt(costMP) || 0;
-        const numSP = parseInt(costSP) || 0;
+        const numAP = parseInt(costAP, 10) || 0;
+        const numMP = parseInt(costMP, 10) || 0;
+        const numSP = parseInt(costSP, 10) || 0;
 
         if (numAP > 0) costStringParts.push(`${numAP} AP`);
         if (numMP > 0) costStringParts.push(`${numMP} MP`);
@@ -112,7 +112,7 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
             costMP: numMP,
             costSP: numSP,
             actionType: category === 'action' ? actionType : null,
-            damageMod: (category === 'action' && (actionType.includes('Attack') || actionType.includes('Spell'))) ? (parseInt(damageMod) || 0) : null,
+            damageMod: (category === 'action' && (actionType.includes('Attack') || actionType.includes('Spell'))) ? (parseInt(damageMod, 10) || 0) : null,
             damageType: (category === 'action' && (actionType.includes('Attack') || actionType.includes('Spell'))) ? damageType.trim() : null,
             range: (category === 'action' || category === 'attack_enhancement' || (category === 'reaction' && actionType)) ? range.trim() : null,
             targets: (category === 'action' || category === 'attack_enhancement' || (category === 'reaction' && actionType)) ? targets.trim() : null,

--- a/dc20-creature-creator/src/components/InputPanel.jsx
+++ b/dc20-creature-creator/src/components/InputPanel.jsx
@@ -111,7 +111,16 @@ const InputPanel = ({
                     </div>
                     <div className="form-group">
                         <label htmlFor="level">Level (0-10+):</label>
-                        <input type="number" id="level" value={level} min="0" onChange={(e) => setLevel(parseInt(e.target.value))} />
+                        <input
+                            type="number"
+                            id="level"
+                            value={level}
+                            min="0"
+                            onChange={(e) => {
+                                const val = parseInt(e.target.value, 10);
+                                setLevel(isNaN(val) ? 0 : val);
+                            }}
+                        />
                     </div>
                     <div className="form-group">
                         <label htmlFor="power">Power Tier:</label>


### PR DESCRIPTION
## Summary
- handle invalid level input in `InputPanel`
- parse cost & damage numbers in `FeatureCreationForm` using base-10

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c27a7a24833193268ec96bf773f9