### PR TITLE
Fix font size

### DIFF
--- a/dc20-creature-creator/src/components/StatBlockPanel.css
+++ b/dc20-creature-creator/src/components/StatBlockPanel.css
@@ -275,7 +275,7 @@
 
 .calculated-defense,
 .calculated-save {
-    font-size: 0.85em;
+    font-size: 1em;
     opacity: 0.8;
     margin-left: 3px;
     white-space: nowrap;


### PR DESCRIPTION
## Summary
- tweak stat block font size for computed defense values

## Testing
- `npx vitest run`
- `npm run lint` *(fails: process not defined, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685860b77e2c83318f363dffa22beb03