### PR TITLE
Fix editable span borders in stats

### DIFF
--- a/dc20-creature-creator/src/components/StatBlockPanel.css
+++ b/dc20-creature-creator/src/components/StatBlockPanel.css
@@ -259,7 +259,6 @@
     white-space: nowrap;
     line-height: 1;
     padding: 1px 2px;
-    border: none;
     background: transparent;
     color: var(--text-color-light);
     /* Ensure text is light */


### PR DESCRIPTION
## Summary
- enable underline styling for PD, AD, attribute, and save numbers

## Testing
- `npm run lint` *(fails: cannot find '@eslint/js' / lint errors)*
- `npm test` *(fails: no tests / command hangs)*

------
https://chatgpt.com/codex/tasks/task_e_685872f12e108331a25494952612b66d