### PR TITLE
Fix duplicate votes field

### DIFF
--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
@@ -259,7 +259,6 @@ const CreatureCreatorPage = ({ currentUser }) => {
       createdAt: serverTimestamp(),
       ownerId: currentUser.uid,
       submittedBy: currentUser.email,
-      votes: 0,
     };
     try {
       const docRef = await addDoc(collection(db, "savedCreatures"), creatureDataToSave);


### PR DESCRIPTION
## Summary
- remove duplicate votes entry when saving a creature

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685889a80db083318b5d840f194ab448