### PR TITLE
Add actions schema and include actions in saved creatures

### DIFF
--- a/dc20-creature-creator/src/data/actionSchema.jsx
+++ b/dc20-creature-creator/src/data/actionSchema.jsx
@@ -1,0 +1,14 @@
+// src/data/actionSchema.jsx
+// Schema definition for creature actions stored with a creature document
+export const creatureActionSchema = {
+  name: '',       // Display name of the action
+  costAP: 0,      // Action point cost
+  costMP: 0,      // Magic point cost
+  damageMod: 0,   // Damage modifier relative to base damage
+  saveDCMod: 0,   // Adjustment applied to Save DC
+  range: '',      // Range information (e.g., "Melee", "5 spaces")
+  targets: '',    // Target description
+  actionType: '', // Classification like "Melee Martial Attack"
+  description: '',// Text describing the action's effect
+  source: '',     // 'feature' for user selected traits or 'default'
+};

--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
@@ -5,6 +5,7 @@ import RightBar from '../components/RightBar';
 import InputPanel from '../components/InputPanel';
 import StatBlockPanel from '../components/StatBlockPanel';
 import { calculateCreatureStats } from '../utils/calculateStats';
+import { creatureActionSchema } from '../data/actionSchema';
 import { db } from '../firebase';
 import { collection, query, getDocs, orderBy, addDoc, serverTimestamp } from 'firebase/firestore';
 
@@ -29,6 +30,7 @@ const CreatureCreatorPage = ({ currentUser }) => {
 
   // --- State for the Final Calculated Stat Block ---
   const [statBlock, setStatBlock] = useState(null);
+  const [actions, setActions] = useState([]);
 
   const [isCreatingFeature, setIsCreatingFeature] = useState(false);
 
@@ -95,6 +97,41 @@ const CreatureCreatorPage = ({ currentUser }) => {
     setStatBlock(newCalculatedStats);
     // console.log("Stat block recalculated with overrides:", newCalculatedStats);
   }, [creatureName, level, power, type, role, size, selectedFeatures, overrides]); // Added 'overrides'
+
+  // --- Effect 5: Build actions array from selected features and default attacks ---
+  useEffect(() => {
+    if (!statBlock) { setActions([]); return; }
+
+    const defaultActions = (statBlock.FinalWithDeltas?.DefaultAttacks || []).map(att => ({
+      name: att.name,
+      costAP: att.costAP || 0,
+      costMP: 0,
+      damageMod: 0,
+      saveDCMod: 0,
+      range: att.range,
+      targets: att.targetDescription,
+      actionType: att.type,
+      description: att.details,
+      source: 'default',
+    }));
+
+    const featureActions = selectedFeatures
+      .filter(f => f.category === 'action')
+      .map(f => ({
+        name: f.name,
+        costAP: f.costAP || 0,
+        costMP: f.costMP || 0,
+        damageMod: f.damageMod || 0,
+        saveDCMod: f.saveDCMod || 0,
+        range: f.range || '',
+        targets: f.targets || '',
+        actionType: f.actionType || '',
+        description: f.descriptionCore || f.description || '',
+        source: 'feature',
+      }));
+
+    setActions([...defaultActions, ...featureActions]);
+  }, [statBlock, selectedFeatures]);
 
   // --- Handler for selecting/deselecting features via checkboxes ---
   const handleFeatureSelect = (feature, isSelected) => {
@@ -238,6 +275,7 @@ const CreatureCreatorPage = ({ currentUser }) => {
     setType('humanoid'); setRole('none'); setSize('medium');
     setSelectedFeatures([]);
     setOverrides({}); // <<< CLEAR OVERRIDES
+    setActions([]);
     setIsCreatingFeature(false);
   };
 
@@ -253,6 +291,7 @@ const CreatureCreatorPage = ({ currentUser }) => {
       type,
       role,
       size,
+      actions,
       selectedFeatureIds: selectedFeatures.map(f => f.id),
       statModifiers: overrides, // Save the deltas/sets
       votes: 0,

--- a/dc20-creature-creator/src/pages/HomePage.jsx
+++ b/dc20-creature-creator/src/pages/HomePage.jsx
@@ -17,7 +17,10 @@ const HomePage = ({ currentUser }) => {
                     limit(3)
                 );
                 const snapshot = await getDocs(q);
-                const data = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                const data = snapshot.docs.map(doc => {
+                    const d = doc.data();
+                    return { id: doc.id, ...d, actions: d.actions || [] };
+                });
                 setHighlightedCreatures(data);
             } catch (err) {
                 console.error('Error fetching creatures:', err);

--- a/dc20-creature-creator/src/pages/MyCreaturesPage.jsx
+++ b/dc20-creature-creator/src/pages/MyCreaturesPage.jsx
@@ -18,7 +18,10 @@ const MyCreaturesPage = ({ currentUser }) => {
                     where('ownerId', '==', currentUser.uid)
                 );
                 const snapshot = await getDocs(q);
-                const data = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                const data = snapshot.docs.map(doc => {
+                    const d = doc.data();
+                    return { id: doc.id, ...d, actions: d.actions || [] };
+                });
                 setAllCreatures(data);
             } catch (err) {
                 console.error('Error fetching creatures:', err);


### PR DESCRIPTION
## Summary
- define `creatureActionSchema`
- maintain actions array in `CreatureCreatorPage`
- save `actions` to Firestore
- ensure loaders read actions from saved docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest` *(fails: needs to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685889b7eb1883319ff1805432fc1c0c