### PR TITLE
Enable editable combat actions

### DIFF
--- a/dc20-creature-creator/src/components/ActionEditor.css
+++ b/dc20-creature-creator/src/components/ActionEditor.css
@@ -1,0 +1,14 @@
+.action-editor {
+    margin: 0.5rem 0;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+}
+.action-field {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.25rem;
+}
+.action-label {
+    margin-right: 0.25rem;
+    font-weight: bold;
+}

--- a/dc20-creature-creator/src/components/ActionEditor.jsx
+++ b/dc20-creature-creator/src/components/ActionEditor.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import EditableField from './EditableField';
+import './ActionEditor.css';
+
+const ActionEditor = ({ action, onChange }) => {
+    if (!action) return null;
+
+    const handleSave = (field, value) => {
+        onChange(field, value);
+    };
+
+    const skip = ['id', 'originalFeatureId', 'displayCost', 'displayDescription', 'category'];
+    return (
+        <div className="action-editor">
+            {Object.entries(action).map(([key, val]) => {
+                if (skip.includes(key)) return null;
+                const fieldType = typeof val === 'number' ? 'number' : 'text';
+                const displayVal = val !== null && val !== undefined ? val : '';
+                return (
+                    <div key={key} className="action-field">
+                        <span className="action-label">{key}:</span>
+                        <EditableField
+                            value={displayVal}
+                            fieldType={fieldType}
+                            fieldName={key}
+                            onSave={(f, v) => handleSave(key, v)}
+                        />
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
+
+export default ActionEditor;

--- a/dc20-creature-creator/src/components/StatBlockPanel.jsx
+++ b/dc20-creature-creator/src/components/StatBlockPanel.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import './StatBlockPanel.css'; // Main CSS for the stat block
 import EditableField from './EditableField';
+import ActionEditor from './ActionEditor';
 import HoverRemoveButton from './HoverRemoveButton';
 import {
     GiHeartPlus, GiRosaShield, GiCrownedExplosion,
@@ -9,7 +10,7 @@ import {
     GiMagicSwirl, GiCrossedSwords, GiUpgrade, GiReturnArrow, GiSandsOfTime
 } from 'react-icons/gi';
 
-const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature }) => {
+const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature, onActionUpdate }) => {
     if (!fullStatBlock || !fullStatBlock.Display || !fullStatBlock.CalculatedBeforeDeltas || !fullStatBlock.FinalWithDeltas) {
         return <div className="stat-block-panel"><p>Calculating stats...</p></div>;
     }
@@ -49,6 +50,12 @@ const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature }) => {
             if (i === pathParts.length - 1) originalCalcValue = tempOriginalValue;
         }
         onStatOverride(fieldName, newAbsoluteValueFromInput, originalCalcValue);
+    };
+
+    const handleActionFieldSave = (actionIndex, field, value) => {
+        if (onActionUpdate) {
+            onActionUpdate(actionIndex, field, value);
+        }
     };
 
 
@@ -213,22 +220,24 @@ const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature }) => {
 
                     </>
 
-                    {display.Combat.Attacks && display.Combat.Attacks.map((attack, index) => (
-                        <div key={attack.originalFeatureId || `attack-${index}`} className="sb-list-item attack-item">
-                            <p>
-                                <EditableField value={attack.name} onSave={(f, val) => handleSave(`Combat_Attacks_${index}_name_set`, val)} fieldName={`Combat_Attacks_${index}_name_set`} fieldType="text" className="editable-name-field" />: {' '}
-                                <EditableField value={attack.details} onSave={(f, val) => handleSave(`Combat_Attacks_${index}_details_set`, val)} fieldName={`Combat_Attacks_${index}_details_set`} fieldType="text" className="editable-description-field" />
-                            </p>
-                            {attack.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(findOriginalItemForRemove(attack, "CombatActions"))} />}
+                    {/* Default attacks remain simple text */}
+                    {display.Combat.Attacks && display.Combat.Attacks.filter(a => !a.originalFeatureId).map((attack, i) => (
+                        <div key={`default-attack-${i}`} className="sb-list-item attack-item">
+                            <p>{attack.name}: {attack.details}</p>
                         </div>
                     ))}
-                    {display.Combat.OtherActions && display.Combat.OtherActions.map((action, index) => (
-                        <div key={action.originalFeatureId || `otheraction-${index}`} className="sb-list-item action-item">
-                            <p>
-                                <EditableField value={action.name} onSave={(f, val) => handleSave(`Combat_OtherActions_${index}_name_set`, val)} fieldName={`Combat_OtherActions_${index}_name_set`} fieldType="text" className="editable-name-field" />: {' '}
-                                <EditableField value={action.details} onSave={(f, val) => handleSave(`Combat_OtherActions_${index}_details_set`, val)} fieldName={`Combat_OtherActions_${index}_details_set`} fieldType="text" className="editable-description-field" />
-                            </p>
-                            {action.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(findOriginalItemForRemove(action, "CombatActions"))} />}
+
+                    {finalRaw.CombatActions && finalRaw.CombatActions.filter(a => a.actionType && (a.actionType.includes('Attack') || a.actionType.includes('Spell'))).map((act, idx) => (
+                        <div key={act.originalFeatureId || `attack-${idx}`} className="sb-list-item attack-item">
+                            <ActionEditor action={act} onChange={(field, val) => handleActionFieldSave(idx, field, val)} />
+                            {act.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(act)} />}
+                        </div>
+                    ))}
+
+                    {finalRaw.CombatActions && finalRaw.CombatActions.filter(a => !a.actionType || !(a.actionType.includes('Attack') || a.actionType.includes('Spell'))).map((act, idx) => (
+                        <div key={act.originalFeatureId || `action-${idx}`} className="sb-list-item action-item">
+                            <ActionEditor action={act} onChange={(field, val) => handleActionFieldSave(idx, field, val)} />
+                            {act.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(act)} />}
                         </div>
                     ))}
                 </div>

--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
@@ -214,6 +214,24 @@ const CreatureCreatorPage = ({ currentUser }) => {
   };
   // --- END OF handleStatOverride DEFINITION ---
 
+  const handleActionUpdate = (actionIndex, field, value) => {
+    setSelectedFeatures(prev => {
+      const actionFeatures = prev.filter(f => f.category === 'action');
+      const target = actionFeatures[actionIndex];
+      if (!target) return prev;
+      const targetId = target.id;
+      return prev.map(f => {
+        if (f.id !== targetId) return f;
+        let newVal = value;
+        if (['costAP','costMP','costSP','damageMod','saveDCMod','rangeValue','areaSize'].includes(field)) {
+          const num = parseInt(value, 10);
+          newVal = isNaN(num) ? 0 : num;
+        }
+        return { ...f, [field]: newVal };
+      });
+    });
+  };
+
 
   // --- Custom Feature Creation Handlers ---
   const handleToggleFeatureCreationForm = () => setIsCreatingFeature(prev => !prev);
@@ -325,6 +343,7 @@ const CreatureCreatorPage = ({ currentUser }) => {
           fullStatBlock={statBlock} // This now contains CalculatedBeforeDeltas, FinalWithDeltas, Display
           onStatOverride={handleStatOverride} // Pass the handler
           onRemoveFeature={handleRemoveSelectedFeature} // Pass this for removing features from stat block
+          onActionUpdate={handleActionUpdate}
         />
         <RightBar
           onCreateNew={handleCreateNew}


### PR DESCRIPTION
## Summary
- add `ActionEditor` component with reusable `EditableField`s
- render selected combat actions using `ActionEditor`
- wire updates through `CreatureCreatorPage` so edits modify selected features

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_685889c60d0c8331895926a01fe775ab