### PR TITLE
Fix default action editing

### DIFF
--- a/dc20-creature-creator/src/components/StatBlockPanel.jsx
+++ b/dc20-creature-creator/src/components/StatBlockPanel.jsx
@@ -220,10 +220,25 @@ const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature, onActi
 
                     </>
 
-                    {/* Default attacks remain simple text */}
-                    {display.Combat.Attacks && display.Combat.Attacks.filter(a => !a.originalFeatureId).map((attack, i) => (
-                        <div key={`default-attack-${i}`} className="sb-list-item attack-item">
-                            <p>{attack.name}: {attack.details}</p>
+                    {/* Default attacks with editable fields */}
+                    {display.Combat.Attacks && display.Combat.Attacks.filter(a => !a.originalFeatureId).map((attack, index) => (
+                        <div key={`default-attack-${index}`} className="sb-list-item attack-item">
+                            <p>
+                                <EditableField
+                                    value={attack.name}
+                                    onSave={(f, val) => handleSave(`Combat_Attacks_${index}_name_set`, val)}
+                                    fieldName={`Combat_Attacks_${index}_name_set`}
+                                    fieldType="text"
+                                    className="editable-name-field"
+                                />:{' '}
+                                <EditableField
+                                    value={attack.details}
+                                    onSave={(f, val) => handleSave(`Combat_Attacks_${index}_details_set`, val)}
+                                    fieldName={`Combat_Attacks_${index}_details_set`}
+                                    fieldType="text"
+                                    className="editable-description-field"
+                                />
+                            </p>
                         </div>
                     ))}
 

--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
@@ -34,7 +34,6 @@ const CreatureCreatorPage = ({ currentUser }) => {
 
   // --- State for the Final Calculated Stat Block ---
   const [statBlock, setStatBlock] = useState(null);
-  const [actions, setActions] = useState([]);
 
   const [isCreatingFeature, setIsCreatingFeature] = useState(false);
 


### PR DESCRIPTION
## Summary
- show default attacks with editable fields again
- remove duplicate action state

## Testing
- `npm test`
- `npm run lint` *(fails: `no-undef` and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68588fbb37f08331839b2e05c40a155c