### PR TITLE
Modify action cost editor

### DIFF
--- a/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
+++ b/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
@@ -31,32 +31,32 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
 
     const renderCost = () => {
         if (costAP === 0 && costMP === 0) return <span>Free</span>;
+
+        const parts = [];
+        if (costAP > 0) parts.push(`${costAP} AP`);
+        if (costMP > 0) parts.push(`${costMP} MP`);
+        const costString = parts.join(' + ');
+
+        const onCostSave = (field, val) => {
+            const apMatch = val.match(/(\d+)\s*AP/i);
+            const mpMatch = val.match(/(\d+)\s*MP/i);
+            const parsedAP = apMatch ? parseInt(apMatch[1], 10) : 0;
+            const parsedMP = mpMatch ? parseInt(mpMatch[1], 10) : 0;
+            if (onSaveField) {
+                onSaveField('costAP', parsedAP);
+                onSaveField('costMP', parsedMP);
+            }
+        };
+
         return (
-            <>
-                {costAP > 0 && (
-                    <>
-                        <EditableField
-                            value={costAP}
-                            onSave={(f, val) => handleSave('costAP', val)}
-                            fieldType="number"
-                            className="editable-number-field"
-                        />{' '}
-                        AP
-                    </>
-                )}
-                {costAP > 0 && costMP > 0 && ' + '}
-                {costMP > 0 && (
-                    <>
-                        <EditableField
-                            value={costMP}
-                            onSave={(f, val) => handleSave('costMP', val)}
-                            fieldType="number"
-                            className="editable-number-field"
-                        />{' '}
-                        MP
-                    </>
-                )}
-            </>
+            <strong>
+                <EditableField
+                    value={costString}
+                    onSave={onCostSave}
+                    fieldType="text"
+                    className="editable-number-field"
+                />
+            </strong>
         );
     };
 

--- a/dc20-creature-creator/src/components/StatBlockPanel.css
+++ b/dc20-creature-creator/src/components/StatBlockPanel.css
@@ -493,6 +493,12 @@
     margin: 0;
 }
 
+/* Bold text like action costs */
+.sb-list-item strong {
+    font-weight: 700;
+    color: var(--text-color-dark);
+}
+
 /* Names of features, actions, etc. */
 .sb-list-item .editable-name-field .editable-span,
 .sb-list-item .editable-name-field .editable-input {


### PR DESCRIPTION
## Summary
- rewrite `renderCost` in `ActionInlineDisplay` to edit the whole cost string
- parse AP/MP values when saving and forward them to parent component
- style `strong` text inside stat block list items for consistent formatting

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68589e0f03d48331a7a9658a0e3110d0