### PR TITLE
handle Combat_Attacks overrides

### DIFF
--- a/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
+++ b/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
@@ -66,4 +66,28 @@ describe('calculateCreatureStats', () => {
     expect(displayAttack.details).toContain('DC 16');
 
   });
+
+  it('applies overrides to default attacks', () => {
+    const inputs = {
+      level: 1,
+      power: 'normal',
+      role: 'none',
+      type: 'beast',
+      size: 'medium',
+      creatureName: 'Override Test'
+    };
+
+    const overrides = {
+      'Combat_Attacks_0_damage_set': 8,
+      'Combat_Attacks_0_name_set': 'Custom Attack',
+      'Combat_Attacks_0_details_set': '8 physical damage vs PD. Target 1 creature within 1 space.'
+    };
+
+    const result = calculateCreatureStats(inputs, [], overrides);
+
+    expect(result.FinalWithDeltas.DefaultAttacks[0].damage).toBe(8);
+    const displayAttack = result.Display.Combat.Attacks[0];
+    expect(displayAttack.name).toBe('Custom Attack (1 AP)');
+    expect(displayAttack.details).toContain('8 physical damage');
+  });
 });

--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -119,9 +119,17 @@ export const calculateCreatureStats = (inputs, selectedRawFeatures, userOverride
 
 
     // --- Step 5.75: Apply User Override DELTAS (and SETS) ---
+    const attackOverrides = [];
     for (const fullOverrideKey in userOverrideDeltas) {
         if (userOverrideDeltas.hasOwnProperty(fullOverrideKey)) {
             const overrideStoredValue = userOverrideDeltas[fullOverrideKey];
+            const attackMatch = fullOverrideKey.match(/^Combat_Attacks_(\d+)_(.+)_(delta|set)$/);
+            if (attackMatch) {
+                const [, idxStr, field, type] = attackMatch;
+                attackOverrides.push({ index: parseInt(idxStr, 10), field, type, value: overrideStoredValue });
+                continue;
+            }
+
             const parts = fullOverrideKey.split('_'); const suffix = parts.pop(); const fieldKey = parts.join('_');
             const [mainKey, subKey] = fieldKey.split('_'); // Re-split fieldKey for nested access
             if (suffix === 'delta' && typeof overrideStoredValue === 'number') {
@@ -344,6 +352,17 @@ export const calculateCreatureStats = (inputs, selectedRawFeatures, userOverride
             targetDescription: "1 creature"
         });
     }
+
+    // Apply any pending overrides to generated default attacks
+    attackOverrides.forEach(ov => {
+        const att = calculated.DefaultAttacks[ov.index];
+        if (!att) return;
+        if (ov.type === 'delta' && typeof ov.value === 'number' && typeof att[ov.field] === 'number') {
+            att[ov.field] = (att[ov.field] || 0) + ov.value;
+        } else if (ov.type === 'set') {
+            att[ov.field] = ov.value;
+        }
+    });
 
     // --- 8. Format for Display ---
     const finalCalcs = calculated;


### PR DESCRIPTION
## Summary
- apply combat attack overrides after parsing user deltas
- ensure default attack overrides persist through recalculation
- test Combat_Attacks overrides

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68589e13ec2c8331a771b87f3e1d39c7