### PR TITLE
Wrap cost with <strong> in ActionInlineDisplay

### DIFF
--- a/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
+++ b/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
@@ -69,7 +69,7 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
                 className="editable-name-field"
             />{' '}
             (
-            {renderCost()}
+            <strong>{renderCost()}</strong>
             ):
             {' '}
             <EditableField


### PR DESCRIPTION
## Summary
- display action cost in bold

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68589e17811c8331a2d7a5f242481584