### PR TITLE
Use select dropdown for defense field

### DIFF
--- a/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
+++ b/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
@@ -85,12 +85,14 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
                 className="editable-description-field"
             />{' '}
             damage vs{' '}
-            <EditableField
+            <select
                 value={targetsDefense}
-                onSave={(f, val) => handleSave('targetsDefense', val)}
-                fieldType="text"
+                onChange={(e) => handleSave('targetsDefense', e.target.value)}
                 className="editable-description-field"
-            />
+            >
+                <option value="PD">PD</option>
+                <option value="AD">AD</option>
+            </select>
             . Target{' '}
             <EditableField
                 value={targetDescription}


### PR DESCRIPTION
## Summary
- swap `EditableField` for a `<select>` on the `targetsDefense` field

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68589e18def48331933dbfa21e0661f3