### PR TITLE
Improve action editing UI

### DIFF
--- a/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
+++ b/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import EditableField from './EditableField';
 
 const ActionInlineDisplay = ({ action, onSaveField }) => {
+    const [isEditingDefense, setIsEditingDefense] = useState(false);
+
     if (!action) return null;
 
     const {
@@ -16,6 +18,7 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
         range,
         rangeValue,
         rangeUnit,
+        details = '',
     } = action;
 
     const finalDamage = typeof damage === 'number' ? damage : (typeof calculatedDamage === 'number' ? calculatedDamage : '');
@@ -85,14 +88,27 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
                 className="editable-description-field"
             />{' '}
             damage vs{' '}
-            <select
-                value={targetsDefense}
-                onChange={(e) => handleSave('targetsDefense', e.target.value)}
-                className="editable-description-field"
-            >
-                <option value="PD">PD</option>
-                <option value="AD">AD</option>
-            </select>
+            {isEditingDefense ? (
+                <select
+                    value={targetsDefense}
+                    onChange={(e) => {
+                        handleSave('targetsDefense', e.target.value);
+                        setIsEditingDefense(false);
+                    }}
+                    onBlur={() => setIsEditingDefense(false)}
+                    className="editable-select"
+                >
+                    <option value="PD">PD</option>
+                    <option value="AD">AD</option>
+                </select>
+            ) : (
+                <span
+                    onDoubleClick={() => setIsEditingDefense(true)}
+                    className="editable-select-span"
+                >
+                    {targetsDefense}
+                </span>
+            )}
             . Target{' '}
             <EditableField
                 value={targetDescription}
@@ -107,6 +123,17 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
                 fieldType="text"
                 className="editable-description-field"
             />.
+            {details && (
+                <>
+                    <br />
+                    <EditableField
+                        value={details}
+                        onSave={(f, val) => handleSave('details', val)}
+                        fieldType="text"
+                        className="editable-description-field"
+                    />
+                </>
+            )}
         </p>
     );
 };

--- a/dc20-creature-creator/src/components/EditableField.css
+++ b/dc20-creature-creator/src/components/EditableField.css
@@ -52,3 +52,23 @@
     /* -moz-appearance: textfield; */
 
 }
+
+/* Editable select styling */
+.editable-select-span {
+    cursor: text;
+    padding: 2px 4px;
+    border: 1px solid var(--color-accent);
+    border-radius: 3px;
+    transition: background-color 0.2s ease-in-out;
+    display: inline-block;
+}
+
+.editable-select-span:hover {
+    background-color: #e0e0e0;
+}
+
+.editable-select {
+    border: 1px solid var(--color-accent);
+    border-radius: 3px;
+    background-color: #f8f9fa;
+}

--- a/dc20-creature-creator/src/components/StatBlockPanel.jsx
+++ b/dc20-creature-creator/src/components/StatBlockPanel.jsx
@@ -269,8 +269,21 @@ const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature, onActi
                     {display.Combat.AttackEnhancements.map((enh, index) => (
                         <div key={enh.originalFeatureId || `enhance-${index}`} className="sb-list-item enhancement-item">
                             <p>
-                                <EditableField value={enh.name} onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_name_set`, val)} fieldName={`Combat_AttackEnhancements_${index}_name_set`} fieldType="text" className="editable-name-field" />: {' '}
-                                <EditableField value={enh.details} onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_details_set`, val)} fieldName={`Combat_AttackEnhancements_${index}_details_set`} fieldType="text" className="editable-description-field" />
+                                <EditableField
+                                    value={enh.name}
+                                    onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_name_set`, val)}
+                                    fieldName={`Combat_AttackEnhancements_${index}_name_set`}
+                                    fieldType="text"
+                                    className="editable-name-field"
+                                />
+                                <br />
+                                <EditableField
+                                    value={enh.details}
+                                    onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_details_set`, val)}
+                                    fieldName={`Combat_AttackEnhancements_${index}_details_set`}
+                                    fieldType="text"
+                                    className="editable-description-field"
+                                />
                             </p>
                             {enh.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(findOriginalItemForRemove(enh, "AttackEnhancements"))} />}
                         </div>


### PR DESCRIPTION
## Summary
- make defense target toggle from text to select on double-click
- show action descriptions on a new line
- format attack enhancement actions to match style
- style editable select field

## Testing
- `npm run lint` *(fails: 'process' is not defined, no-unused-vars, etc.)*
- `npm exec vitest run` *(fails: calculateCreatureStats applies overrides to default attacks)*

------
https://chatgpt.com/codex/tasks/task_e_6859044267e883318ef87ccec0b6de28