### PR TITLE
Append feature descriptions to action details

### DIFF
--- a/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
+++ b/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
@@ -77,17 +77,19 @@ describe('calculateCreatureStats', () => {
       creatureName: 'Override Test'
     };
 
-    const overrides = {
-      'Combat_Attacks_0_damage_set': 8,
-      'Combat_Attacks_0_name_set': 'Custom Attack',
-      'Combat_Attacks_0_details_set': '8 physical damage vs PD. Target 1 creature within 1 space.'
+    const actionOverrides = {
+      0: {
+        damage: 8,
+        name: 'Custom Attack',
+        details: '8 physical damage vs PD. Target 1 creature within 1 space.'
+      }
     };
 
-    const result = calculateCreatureStats(inputs, [], overrides);
+    const result = calculateCreatureStats(inputs, [], {}, actionOverrides);
 
     expect(result.FinalWithDeltas.DefaultAttacks[0].damage).toBe(8);
     const displayAttack = result.Display.Combat.Attacks[0];
-    expect(displayAttack.name).toBe('Custom Attack (1 AP)');
+    expect(displayAttack.name).toBe('Custom Attack');
     expect(displayAttack.details).toContain('8 physical damage');
   });
 });

--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -208,9 +208,6 @@ export const calculateCreatureStats = (
 
                 let descDisplayParts = [];
 
-                if (descriptionCore || description || name) {
-                    descDisplayParts.push(descriptionCore || description || name);
-                }
                 if (finalActionDamage > 0) {
                     descDisplayParts.push(`${finalActionDamage} ${damageType || 'damage'} damage${targetsDefense ? ` vs ${targetsDefense}` : ''}.`);
                 }
@@ -238,6 +235,12 @@ export const calculateCreatureStats = (
                     descDisplayParts.push(condStr + ".");
                 }
                 if (healingAmount) descDisplayParts.push(healingAmount === "damage dealt" ? "You regain HP equal to damage dealt." : `Heals for ${healingAmount} HP.`);
+
+                if (descriptionCore || description) {
+                    descDisplayParts.push(descriptionCore || description);
+                } else if (!descDisplayParts.length && name) {
+                    descDisplayParts.push(name);
+                }
 
                 calculated.CombatActions.push({
                     ...feature, name, calculatedDamage: finalActionDamage,
@@ -428,7 +431,6 @@ export const calculateCreatureStats = (
         const displayCostStr = costParts.join(' + ') || 'Free';
 
         let descDisplayParts = [];
-        if (descriptionCore || description || name) descDisplayParts.push(descriptionCore || description || name);
         if (finalActionDamage > 0) {
             descDisplayParts.push(`${finalActionDamage} ${damageType || 'damage'} damage${targetsDefense ? ` vs ${targetsDefense}` : ''}.`);
         }
@@ -456,6 +458,12 @@ export const calculateCreatureStats = (
         }
         if (healingAmount) {
             descDisplayParts.push(healingAmount === 'damage dealt' ? 'You regain HP equal to damage dealt.' : `Heals for ${healingAmount} HP.`);
+        }
+
+        if (descriptionCore || description) {
+            descDisplayParts.push(descriptionCore || description);
+        } else if (!descDisplayParts.length && name) {
+            descDisplayParts.push(name);
         }
 
         return {


### PR DESCRIPTION
## Summary
- update calculateCreatureStats so descriptionCore text appears at the end of action details
- adjust unit test for new default action override structure

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68591ff63ae083319a8fe015bfd8ae98