### PR TITLE
Update attack enhancement description

### DIFF
--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -251,13 +251,38 @@ export const calculateCreatureStats = (
                 });
                 break;
             case 'attack_enhancement':
-                let enhDescParts = [descriptionCore || description || name || ''];
+                let enhDescParts = [];
                 if (saveAttribute) {
                     const enhSaveDC = (calculated.SaveDC || 0) + (saveDCMod || 0);
                     enhDescParts.push(`Target makes a ${saveAttribute} save (DC ${enhSaveDC})`);
                 }
-                if (conditionApplied) enhDescParts.push(conditionApplied ? `or becomes ${conditionApplied}${conditionDuration ? ` (${conditionDuration.replace("your", "its")})` : ''}` : '');
-                calculated.AttackEnhancements.push({ ...feature, name, cost: costAP > 0 ? `+${costAP} AP` : (costMP > 0 ? `+${costMP} MP` : 'Special'), description: enhDescParts.filter(Boolean).join('. '), originalFeatureId: id || originalFeatureId });
+                if (conditionApplied) {
+                    enhDescParts.push(
+                        conditionApplied
+                            ? `or becomes ${conditionApplied}${
+                                  conditionDuration
+                                      ? ` (${conditionDuration.replace("your", "its")})`
+                                      : ''
+                              }`
+                            : ''
+                    );
+                }
+                if (descriptionCore || description) {
+                    enhDescParts.push(descriptionCore || description);
+                }
+                if (!enhDescParts.length && name) enhDescParts.push(name);
+                calculated.AttackEnhancements.push({
+                    ...feature,
+                    name,
+                    cost:
+                        costAP > 0
+                            ? `+${costAP} AP`
+                            : costMP > 0
+                            ? `+${costMP} MP`
+                            : 'Special',
+                    description: enhDescParts.filter(Boolean).join('. '),
+                    originalFeatureId: id || originalFeatureId,
+                });
                 break;
             case 'reaction':
                 calculated.Reactions.push({ ...feature, name, cost: costAP > 0 ? `${costAP} AP` : 'Reaction', description: descriptionCore || description, originalFeatureId: id || originalFeatureId });


### PR DESCRIPTION
## Summary
- refine Attack Enhancement description build order in `calculateStats`

## Testing
- `npm test`
- `npm run lint` *(fails: `no-undef`, `no-unused-vars`, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68594bb01b8883319225f06b7f57663f