### PR TITLE
Fix action descriptions and enhancement duplication

### DIFF
--- a/dc20-creature-creator/src/components/StatBlockPanel.jsx
+++ b/dc20-creature-creator/src/components/StatBlockPanel.jsx
@@ -243,7 +243,7 @@ const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature, onActi
                     {finalRaw.CombatActions && finalRaw.CombatActions.filter(a => a.actionType && (a.actionType.includes('Attack') || a.actionType.includes('Spell'))).map((act, idx) => (
                         <div key={act.originalFeatureId || `attack-${idx}`} className="sb-list-item attack-item">
                             <ActionInlineDisplay
-                                action={act}
+                                action={{ ...act, details: act.details || act.displayDescription }}
                                 onSaveField={(field, val) => handleActionFieldSave(idx, field, val)}
                             />
                             {act.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(act)} />}
@@ -253,7 +253,7 @@ const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature, onActi
                     {finalRaw.CombatActions && finalRaw.CombatActions.filter(a => !a.actionType || !(a.actionType.includes('Attack') || a.actionType.includes('Spell'))).map((act, idx) => (
                         <div key={act.originalFeatureId || `action-${idx}`} className="sb-list-item action-item">
                             <ActionInlineDisplay
-                                action={act}
+                                action={{ ...act, details: act.details || act.displayDescription }}
                                 onSaveField={(field, val) => handleActionFieldSave(idx, field, val)}
                             />
                             {act.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(act)} />}

--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -254,7 +254,12 @@ export const calculateCreatureStats = (
             case 'attack_enhancement':
 
             {
-                let enhDescParts = [descriptionCore || description || name || ''];
+                let enhDescParts = [];
+                if (descriptionCore || description) {
+                    enhDescParts.push(descriptionCore || description);
+                } else if (name) {
+                    enhDescParts.push(name);
+                }
 
                 if (saveAttribute) {
                     const enhSaveDC = (calculated.SaveDC || 0) + (saveDCMod || 0);
@@ -271,9 +276,7 @@ export const calculateCreatureStats = (
                             : ''
                     );
                 }
-                if (descriptionCore || description) {
-                    enhDescParts.push(descriptionCore || description);
-                }
+                // description already added above
                 if (!enhDescParts.length && name) enhDescParts.push(name);
                 calculated.AttackEnhancements.push({
                     ...feature,


### PR DESCRIPTION
## Summary
- ensure combat actions render description text by passing it explicitly
- avoid repeating descriptions for attack enhancements

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68594e6253548331a22a813fad877cbf