### PR TITLE
Add new passive features, actions, and attack enhancements

### DIFF
--- a/dc20-creature-creator/src/uploadFeatures.cjs
+++ b/dc20-creature-creator/src/uploadFeatures.cjs
@@ -51,6 +51,39 @@ const allCreatureFeatures = [
         effects: [{ stat: "Speed", change: "add", value: 1 }]
     },
 
+    {
+        id: "feature_bulwark_guard",
+        name: "Bulwark Guard",
+        descriptionCore: "While you haven’t moved this turn, you gain +1 PD and +1 AD until the start of your next turn.",
+        category: "feature",
+        tags: ["defender", "soldier"],
+        effects: [
+            { stat: "PD", change: "add", value: 1, conditional: "no_movement_this_turn" },
+            { stat: "AD", change: "add", value: 1, conditional: "no_movement_this_turn" }
+        ]
+    },
+    {
+        id: "feature_predators_pounce",
+        name: "Predator’s Pounce",
+        descriptionCore: "If you move at least 3 Spaces in a straight line before a Melee Attack, that Attack deals +1 damage.",
+        category: "feature",
+        tags: ["brute", "skirmisher", "beast"]
+    },
+    {
+        id: "feature_arcanist_overwatch",
+        name: "Arcanist Overwatch",
+        descriptionCore: "When a creature within 5 Spaces uses a MP effect, you gain a Help Die usable on your next Spell Attack this round.",
+        category: "feature",
+        tags: ["artillerist", "controller", "spellcaster"]
+    },
+    {
+        id: "feature_glacial_footing",
+        name: "Glacial Footing",
+        descriptionCore: "You ignore Difficult Terrain created by ice/snow, and effects cannot reduce your Speed below 2 while you’re on such terrain.",
+        category: "feature",
+        tags: ["controller", "elemental", "construct"]
+    },
+
     // --- SENSES, IMMUNITIES, RESISTANCES, VULNERABILITIES ---
     { /* ... Darkvision, Blindsight, Immunities, Resistances, Vulnerabilities from your previous list, ensure 'descriptionCore' is used for description ... */
         id: "common_darkvision_60", name: "Darkvision", descriptionCore: "You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light.", category: "sense", value: "Darkvision 60ft", tags: ["humanoid", "beast", "undead"]
@@ -60,6 +93,23 @@ const allCreatureFeatures = [
     },
     {
         id: "fiend_fire_resistance", name: "Fiendish Resilience (Fire)", descriptionCore: "You have resistance to fire damage.", category: "resistance", value: "fire", displayValue: "Fire", tags: ["fiend"]
+    },
+    {
+        id: "sense_truescent_10",
+        name: "Truescent",
+        descriptionCore: "You can precisely sense creatures by smell within 10 Spaces even if Invisible or behind cover.",
+        category: "sense",
+        value: "Truescent 10",
+        tags: ["beast", "monstrosity", "tracker"]
+    },
+    {
+        id: "resistance_thunderhide",
+        name: "Thunderhide",
+        descriptionCore: "Your hide disperses force: you have resistance to Sonic damage.",
+        category: "resistance",
+        value: "sonic",
+        displayValue: "Sonic",
+        tags: ["beast", "monstrosity", "construct"]
     },
     // ... (add others similarly)
 
@@ -193,6 +243,97 @@ const allCreatureFeatures = [
         conditionDuration: "instantaneous (effect happens now)", // Or "1 round" if they can't pick it up
     },
 
+    {
+        id: "action_shieldbash_lockstep",
+        name: "Shieldbash Lockstep",
+        category: "action",
+        actionType: "Melee Martial Attack",
+        tags: ["defender", "control"],
+        descriptionCore: "You slam and lock the foe in place while stepping with them.",
+        costAP: 1, costMP: 0, costSP: 0,
+        damageMod: 0, damageType: "physical",
+        targetsDefense: "PD",
+        rangeValue: 1, rangeUnit: "space",
+        targetDescription: "1 creature",
+        saveAttribute: "Physical",
+        conditionApplied: "Hindered",
+        conditionDuration: "until it resolves its next Attack",
+        // rider: if failure by 5+, also Slowed until end of its next turn
+    },
+    {
+        id: "action_ice_wall",
+        name: "Ice Wall",
+        category: "action",
+        actionType: "Zone Control Spell",
+        tags: ["controller", "cold", "zone"],
+        descriptionCore: "Conjure a low wall of jagged ice that blocks movement and shapes the battlefield.",
+        costAP: 2, costMP: 2, costSP: 0,
+        damageMod: 0, damageType: "cold",
+        targetsDefense: "AD",
+        rangeValue: 8, rangeUnit: "space",
+        areaShape: "wall",
+        areaSize: 5, // 5-space wall, 1-space thick
+        targetDescription: "a 5-space wall",
+        saveAttribute: "Physical",
+        // Entering a wall Space or being pushed through it: 1 Cold; Failure: Slowed until end of next turn
+    },
+    {
+        id: "action_chain_bolt",
+        name: "Chain Bolt",
+        category: "action",
+        actionType: "Ranged Spell Attack",
+        tags: ["artillerist", "lightning", "multi-target"],
+        descriptionCore: "A crackling bolt leaps between targets.",
+        costAP: 1, costMP: 1, costSP: 0,
+        damageMod: 0, damageType: "lightning",
+        targetsDefense: "PD",
+        rangeValue: 10, rangeUnit: "space",
+        targetDescription: "1 creature; on hit, arcs to up to 2 additional creatures within 2 Spaces of the previous target (each separate Attack vs PD at −1 damageMod)."
+    },
+    {
+        id: "action_galestep_cut",
+        name: "Galestep Cut",
+        category: "action",
+        actionType: "Melee Martial Attack",
+        tags: ["lurker", "mobility", "hit-and-run"],
+        descriptionCore: "You strike and slip out on the wind.",
+        costAP: 1, costMP: 0, costSP: 0,
+        damageMod: 0, damageType: "physical",
+        targetsDefense: "PD",
+        rangeValue: 1, rangeUnit: "space",
+        targetDescription: "1 creature",
+        // After the Attack, you may Disengage and move up to 2 Spaces.
+    },
+    {
+        id: "action_gravitic_pulse",
+        name: "Gravitic Pulse",
+        category: "action",
+        actionType: "Area Spell Attack",
+        tags: ["controller", "zone", "force"],
+        descriptionCore: "A crushing pulse collapses inward, dragging creatures.",
+        costAP: 2, costMP: 2, costSP: 0,
+        damageMod: 0, damageType: "force",
+        targetsDefense: "AD",
+        rangeValue: 8, rangeUnit: "space",
+        areaShape: "sphere",
+        areaSize: 2,
+        targetDescription: "creatures in a 2-space sphere",
+        saveAttribute: "Physical",
+        // Failure: pulled up to 2 Spaces toward center; on Heavy Hit, also Prone.
+    },
+    {
+        id: "action_command_rally",
+        name: "Command: Rally",
+        category: "action",
+        actionType: "Buff",
+        tags: ["leader", "support", "aura"],
+        descriptionCore: "You bark orders that steel your allies.",
+        costAP: 1, costMP: 0, costSP: 0,
+        rangeValue: 5, rangeUnit: "space",
+        targetDescription: "up to 2 allies you can see",
+        // Each target gains a Help Die and +1 Speed until end of its next turn. If a target spends the Help Die on an Attack, it also gains +1 damage on that Attack.
+    },
+
 
     // --- ATTACK ENHANCEMENTS ---
     {
@@ -207,6 +348,49 @@ const allCreatureFeatures = [
         saveAttribute: "Cha",
         conditionApplied: "Stunned",
         conditionDuration: "end of its next turn",
+    },
+    {
+        id: "enhance_cleave_arc",
+        name: "Cleave Arc",
+        category: "attack_enhancement",
+        tags: ["martial", "aoe"],
+        descriptionCore: "When your Melee Attack hits, the blow sweeps onward.",
+        costAP: 0, costMP: 0, costSP: 0,
+        targetsDefense: "AD",
+        // Effect: One additional creature adjacent to the target takes your damage with damageMod: -1 (Area vs AD).
+    },
+    {
+        id: "enhance_hemorrhage",
+        name: "Hemorrhage",
+        category: "attack_enhancement",
+        tags: ["brute", "bleed"],
+        descriptionCore: "Your strike opens a vicious wound.",
+        costAP: 0, costMP: 0, costSP: 0,
+        saveAttribute: "Physical",
+        conditionApplied: "Bleeding",
+        conditionDuration: "standard Bleeding duration"
+    },
+    {
+        id: "enhance_freezing_mark",
+        name: "Freezing Mark",
+        category: "attack_enhancement",
+        tags: ["cold", "control"],
+        descriptionCore: "Frost clings to the target’s limbs.",
+        costAP: 0, costMP: 1, costSP: 0,
+        saveAttribute: "Agility",
+        conditionApplied: "Slowed",
+        conditionDuration: "until end of its next turn"
+    },
+    {
+        id: "enhance_domineering_taunt",
+        name: "Domineering Taunt",
+        category: "attack_enhancement",
+        tags: ["defender", "taunt"],
+        descriptionCore: "You draw your foe’s focus with brutal bravado.",
+        costAP: 0, costMP: 0, costSP: 0,
+        saveAttribute: "Charisma",
+        conditionApplied: "Taunted",
+        conditionDuration: "until start of your next turn"
     },
 ];
 


### PR DESCRIPTION
## Summary
- include Bulwark Guard, Predator's Pounce, Arcanist Overwatch, and Glacial Footing features
- add Truescent sense and Thunderhide resistance entries
- define Shieldbash Lockstep, Ice Wall, Chain Bolt, Galestep Cut, Gravitic Pulse, and Command: Rally actions
- introduce Cleave Arc, Hemorrhage, Freezing Mark, and Domineering Taunt attack enhancements

## Testing
- `npm test` (fails: expected 12 to be 9; expected '4 fire damage vs PD.' to match)


------
https://chatgpt.com/codex/tasks/task_e_68c28fd38cd08331a7078af8715fab97