### PR TITLE
feat: add apex actions and legendary points

### DIFF
--- a/dc20-creature-creator/src/components/InputPanel.jsx
+++ b/dc20-creature-creator/src/components/InputPanel.jsx
@@ -13,6 +13,7 @@ const InputPanel = ({
     allFeatures,             // <<< NEW: All features from App.jsx
     availableTypeFeatures,   // Pre-filtered by App.jsx
     availableRoleFeatures,   // Pre-filtered by App.jsx
+    availableApexActions,
     selectedFeatures,
     onFeatureSelect,
     onRemoveSelectedFeature,
@@ -184,7 +185,7 @@ const InputPanel = ({
                         </div>
                     ) : (
                         // Otherwise (no active search term), show the type and role filtered lists
-                        <>
+                        <> 
                             <div className="available-features-group">
                                 <h3>Available by Type ({type})</h3>
                                 <div className="feature-list-container">
@@ -195,6 +196,12 @@ const InputPanel = ({
                                 <h3>Available by Role ({role})</h3>
                                 <div className="feature-list-container">
                                     {renderFeatureItems(availableRoleFeatures, 'role-list')}
+                                </div>
+                            </div>
+                            <div className="available-features-group">
+                                <h3>Apex Actions</h3>
+                                <div className="feature-list-container">
+                                    {renderFeatureItems(availableApexActions, 'apex-list')}
                                 </div>
                             </div>
                         </>

--- a/dc20-creature-creator/src/components/StatBlockPanel.jsx
+++ b/dc20-creature-creator/src/components/StatBlockPanel.jsx
@@ -199,6 +199,7 @@ const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature, onActi
                             <span>CHECK: <EditableField value={display.Combat.Check.replace('+', '')} onSave={(f, val) => handleSave("Combat_Check", val)} fieldName="Combat_Check" fieldType="text" /></span>
                             <span>SAVE DC: <EditableField value={display.Combat.SaveDC} onSave={(f, val) => handleSave("Combat_SaveDC", val)} fieldName="Combat_SaveDC" /></span>
                             <span>AP: <EditableField value={display.Combat.AP} onSave={(f, val) => handleSave("Combat_AP", val)} fieldName="Combat_AP" /></span>
+                            {display.Combat.LAP && <span>LAP: <EditableField value={display.Combat.LAP} onSave={(f, val) => handleSave("Combat_LAP", val)} fieldName="Combat_LAP" /></span>}
                             <span>SPEED: <EditableField value={display.Combat.Speed} onSave={(f, val) => handleSave("Combat_Speed", val)} fieldName="Combat_Speed" /></span>
                         </div>
                     </div>
@@ -302,6 +303,22 @@ const StatBlockPanel = ({ fullStatBlock, onStatOverride, onRemoveFeature, onActi
                                 <EditableField value={reaction.details} onSave={(f, val) => handleSave(`Reactions_${index}_details_set`, val)} fieldName={`Reactions_${index}_details_set`} fieldType="text" className="editable-description-field" />
                             </p>
                             {reaction.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(findOriginalItemForRemove(reaction, "Reactions"))} />}
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* --- Apex Actions --- */}
+            {display.ApexActions && display.ApexActions.length > 0 && (
+                <div className="sb-sub-section apex-actions-section">
+                    <h4 className="sb-sub-section-title"><GiCrownedExplosion className="sb-section-icon" />Apex Actions</h4>
+                    {display.ApexActions.map((apex, index) => (
+                        <div key={apex.originalFeatureId || `apex-${index}`} className="sb-list-item apex-action-item">
+                            <p>
+                                <EditableField value={apex.name} onSave={(f, val) => handleSave(`ApexActions_${index}_name_set`, val)} fieldName={`ApexActions_${index}_name_set`} fieldType="text" className="editable-name-field" />: {' '}
+                                <EditableField value={apex.details} onSave={(f, val) => handleSave(`ApexActions_${index}_details_set`, val)} fieldName={`ApexActions_${index}_details_set`} fieldType="text" className="editable-description-field" />
+                            </p>
+                            {apex.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(findOriginalItemForRemove(apex, "ApexActions"))} />}
                         </div>
                     ))}
                 </div>

--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
@@ -25,6 +25,7 @@ const CreatureCreatorPage = ({ currentUser }) => {
   const [isLoadingAllFeatures, setIsLoadingAllFeatures] = useState(true);
   const [availableTypeFeatures, setAvailableTypeFeatures] = useState([]);
   const [availableRoleFeatures, setAvailableRoleFeatures] = useState([]);
+  const [availableApexActions, setAvailableApexActions] = useState([]);
   const [selectedFeatures, setSelectedFeatures] = useState([]);
   const [actions, setActions] = useState([]);
 
@@ -60,6 +61,7 @@ const CreatureCreatorPage = ({ currentUser }) => {
           ...doc.data()
         }));
         setAllFeatures(featuresData);
+        setAvailableApexActions(featuresData.filter(f => f.category === 'apex_action'));
         // console.log(`Fetched ${featuresData.length} total features.`);
       } catch (error) {
         console.error("Error fetching all features:", error);
@@ -413,6 +415,7 @@ const CreatureCreatorPage = ({ currentUser }) => {
           allFeatures={allFeatures}
           availableTypeFeatures={availableTypeFeatures}
           availableRoleFeatures={availableRoleFeatures}
+          availableApexActions={availableApexActions}
           selectedFeatures={selectedFeatures}
           onFeatureSelect={handleFeatureSelect}
           onRemoveSelectedFeature={handleRemoveSelectedFeature}

--- a/dc20-creature-creator/src/uploadFeatures.cjs
+++ b/dc20-creature-creator/src/uploadFeatures.cjs
@@ -405,6 +405,35 @@ const allCreatureFeatures = [
         conditionApplied: "Taunted",
         conditionDuration: "until start of your next turn"
     },
+
+    // --- APEX ACTIONS ---
+    {
+        id: "apex_devastating_strike",
+        name: "Devastating Strike",
+        category: "apex_action",
+        actionType: "Melee Martial Attack",
+        tags: ["apex"],
+        descriptionCore: "You unleash a crushing melee blow dealing +2 damage.",
+        costAP: 1, costMP: 0, costSP: 0,
+        damageMod: 2,
+        targetsDefense: "PD",
+        rangeValue: 1, rangeUnit: "space",
+        targetDescription: "1 creature",
+    },
+    {
+        id: "apex_mythic_roar",
+        name: "Mythic Roar",
+        category: "apex_action",
+        actionType: "Spell",
+        tags: ["apex"],
+        descriptionCore: "Each enemy within 3 spaces must succeed on a CHA save or become frightened for 1 round.",
+        costAP: 2, costMP: 0, costSP: 0,
+        rangeValue: 3, rangeUnit: "space",
+        targetDescription: "all enemies",
+        saveAttribute: "Cha",
+        conditionApplied: "Frightened",
+        conditionDuration: "1 round",
+    },
 ];
 
 async function uploadFeatures() {

--- a/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
+++ b/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
@@ -92,4 +92,34 @@ describe('calculateCreatureStats', () => {
     expect(displayAttack.name).toBe('Custom Attack');
     expect(displayAttack.details).toContain('8 physical damage');
   });
+
+  it('assigns LAP and formats apex actions', () => {
+    const inputs = {
+      level: 1,
+      power: 'apex',
+      role: 'none',
+      type: 'beast',
+      size: 'medium',
+      creatureName: 'Apex Test'
+    };
+
+    const apexAction = {
+      id: 'apex_test_action',
+      name: 'Tail Sweep',
+      category: 'apex_action',
+      costAP: 1,
+      descriptionCore: 'Swipe your tail at a foe.',
+      actionType: 'Melee Attack',
+      rangeValue: 1,
+      rangeUnit: 'space',
+      targetDescription: '1 creature'
+    };
+
+    const result = calculateCreatureStats(inputs, [apexAction], {});
+    expect(result.FinalWithDeltas.LAP).toBe(3);
+    expect(result.Display.Combat.LAP).toBe('3');
+    const aa = result.Display.ApexActions.find(a => a.name.startsWith('Tail Sweep'));
+    expect(aa).toBeDefined();
+    expect(aa.details).toContain('Swipe your tail');
+  });
 });

--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -20,12 +20,12 @@ export const calculateCreatureStats = (
     let calculated = {
         Name: creatureName || "Unnamed Creature",
         Level: level, Power: power, Type: type, Role: role, Size: size,
-        HP: 0, PD: 0, AD: 0, Check: 0, Damage: 0, AP: 0, Speed: 0, MaxMP: 0,
+        HP: 0, PD: 0, AD: 0, Check: 0, Damage: 0, AP: 0, LAP: 0, Speed: 0, MaxMP: 0,
         Attributes: { Mig: 0, Agi: 0, Cha: 0, Int: 0, Prime: 0 },
         Saves: { Mig: null, Agi: null, Cha: null, Int: null },
         Skills: {}, Resistances: [], Vulnerabilities: [], Immunities: [],
         Senses: [], Languages: [], Features: [], CombatActions: [],
-        Reactions: [], AttackEnhancements: [], PDR: '', Range: "Melee",
+        ApexActions: [], Reactions: [], AttackEnhancements: [], PDR: '', Range: "Melee",
         isCaster: false, isMartial: true, SaveDC: 10, DefaultAttacks: [],
     };
 
@@ -71,6 +71,8 @@ export const calculateCreatureStats = (
     } else {
         console.warn(`Power scale not found for: ${power}.`);
     }
+
+    calculated.LAP = power === 'apex' ? 3 : power === 'legendary' ? 6 : 0;
 
     // --- 2.5. Apply Size-Based Defense/Attack Modifiers ---
     // For each size step above medium: AD +1, PD -1; for each below: AD -1, PD +1
@@ -257,6 +259,67 @@ export const calculateCreatureStats = (
                     ...feature, name, calculatedDamage: finalActionDamage,
                     calculatedSaveDC: (calculated.SaveDC || 0) + (saveDCMod || 0),
                     displayCost: displayCostStr,
+                    displayDescription: descDisplayParts.filter(p => p && p.trim() !== '').join(' '),
+                    originalFeatureId: id || originalFeatureId
+                });
+                break;
+            }
+            case 'apex_action': {
+                let finalActionDamage = 0;
+                if (actionType && (actionType.includes("Attack") || actionType.includes("Spell"))) {
+                    if (typeof feature.baseDamageOverride === 'number') {
+                        finalActionDamage = feature.baseDamageOverride + damageMod;
+                    } else {
+                        finalActionDamage = (calculated.Damage || 0) + damageMod;
+                    }
+                }
+
+                let costParts = [];
+                if (costAP > 0) costParts.push(`${costAP} AP`);
+                if (costMP > 0) costParts.push(`${costMP} MP`);
+                let displayCostStr = costParts.join(' + ') || 'Free';
+
+                let descDisplayParts = [];
+
+                if (finalActionDamage > 0) {
+                    descDisplayParts.push(`${finalActionDamage} ${damageType || 'damage'} damage${targetsDefense ? ` vs ${targetsDefense}` : ''}.`);
+                }
+                let targetInfo = targetDescription || (areaShape ? (areaSize ? `${areaSize}-space ${areaShape}` : areaShape) : 'target');
+
+                let rangeInfo = '';
+                if (rangeValue > 0 && rangeUnit === 'space') {
+                    rangeInfo = `${rangeValue} space(s)`;
+                } else if (rangeUnit) {
+                    rangeInfo = rangeUnit.charAt(0).toUpperCase() + rangeUnit.slice(1);
+                }
+                if (targetInfo || rangeInfo) {
+                    descDisplayParts.push(`Target ${targetInfo}${rangeInfo ? ` within ${rangeInfo}` : ''}.`);
+                }
+
+                if (saveAttribute) {
+                    const finalActionSaveDC = (calculated.SaveDC || 0) + (saveDCMod || 0);
+                    let saveStr = `Target makes a ${saveAttribute} save (DC ${finalActionSaveDC})`;
+                    saveStr += conditionApplied ? ` or becomes ${conditionApplied}` : ` for effect`;
+                    if (conditionApplied && conditionDuration) saveStr += ` (${conditionDuration.replace("your", "its")})`;
+                    descDisplayParts.push(saveStr + ".");
+                } else if (conditionApplied) {
+                    let condStr = `Applies ${conditionApplied}`;
+                    if (conditionDuration) condStr += ` (${conditionDuration.replace("your", "its")})`;
+                    descDisplayParts.push(condStr + ".");
+                }
+                if (healingAmount) descDisplayParts.push(healingAmount === "damage dealt" ? "You regain HP equal to damage dealt." : `Heals for ${healingAmount} HP.`);
+
+                if (descriptionCore || description) {
+                    descDisplayParts.push(descriptionCore || description);
+                } else if (!descDisplayParts.length && name) {
+                    descDisplayParts.push(name);
+                }
+
+                calculated.ApexActions.push({
+                    ...feature, name,
+                    calculatedDamage: finalActionDamage,
+                    calculatedSaveDC: (calculated.SaveDC || 0) + (saveDCMod || 0),
+                    cost: displayCostStr,
                     displayDescription: descDisplayParts.filter(p => p && p.trim() !== '').join(' '),
                     originalFeatureId: id || originalFeatureId
                 });
@@ -534,11 +597,12 @@ export const calculateCreatureStats = (
             Features: finalCalcs.Features.map(f => ({ name: f.name, description: f.description, originalFeatureId: f.originalFeatureId })),
             Combat: {
                 Check: `${finalCalcs.Check >= 0 ? '+' : ''}${finalCalcs.Check}`, SaveDC: finalCalcs.SaveDC.toString(),
-                AP: finalCalcs.AP.toString(), Speed: finalCalcs.Speed.toString(),
+                AP: finalCalcs.AP.toString(), LAP: finalCalcs.LAP > 0 ? finalCalcs.LAP.toString() : '', Speed: finalCalcs.Speed.toString(),
                 Attacks: displayAttacks, OtherActions: otherDisplayCombatActions,
                 AttackEnhancements: finalCalcs.AttackEnhancements.map(enh => ({ name: `${enh.name} (${enh.cost || 'Special'})`, details: enh.description, originalFeatureId: enh.originalFeatureId })),
             },
             Reactions: finalCalcs.Reactions.map(re => ({ name: `${re.name} (${re.cost || 'Reaction'})`, details: re.description, originalFeatureId: re.originalFeatureId })),
+            ApexActions: finalCalcs.ApexActions.map(aa => ({ name: `${aa.name} (${aa.cost || 'Free'})`, details: aa.displayDescription || aa.description, originalFeatureId: aa.originalFeatureId })),
         }
     };
 };


### PR DESCRIPTION
## Summary
- display new legendary action points and Apex Actions in stat block
- allow selecting Apex Actions in creature creator
- seed example Apex Action features

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c29516d4148331a87390fd6ef53913