### PR TITLE
Round damage up to nearest integer

### DIFF
--- a/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
+++ b/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
@@ -20,7 +20,7 @@ describe('calculateCreatureStats', () => {
     expect(final.PD).toBe(12);
     expect(final.AD).toBe(12);
     expect(final.Check).toBe(4);
-    expect(final.Damage).toBeCloseTo(1.5);
+    expect(final.Damage).toBe(2);
     expect(final.AP).toBe(4);
     expect(final.Speed).toBe(5);
     expect(final.MaxMP).toBe(0);
@@ -62,7 +62,7 @@ describe('calculateCreatureStats', () => {
     const result = calculateCreatureStats(inputs, [action], {});
     const displayAttack = result.Display.Combat.Attacks.find(a => a.name.startsWith('Fiery Strike'));
     expect(displayAttack).toBeDefined();
-    expect(displayAttack.details).toContain('3.5 fire damage vs PD.');
+    expect(displayAttack.details).toContain('4 fire damage vs PD.');
     expect(displayAttack.details).toContain('DC 16');
 
   });

--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -172,6 +172,9 @@ export const calculateCreatureStats = (
     }
     if (roleMods.AttributePriority) calculated.Attributes.Prime = calculated.Attributes[roleMods.AttributePriority[0]] || 0;
 
+    // Round up final damage after all base modifications and user overrides
+    calculated.Damage = Math.ceil(calculated.Damage);
+
 
     // --- Recalculate Dependent Values (Saves, SaveDC) AFTER all modifications ---
     const CM_final = Math.ceil(calculated.Level / 2);
@@ -211,6 +214,7 @@ export const calculateCreatureStats = (
                     } else {
                         finalActionDamage = (calculated.Damage || 0) + damageMod;
                     }
+                    finalActionDamage = Math.ceil(finalActionDamage);
                 }
 
                 let costParts = [];
@@ -272,6 +276,7 @@ export const calculateCreatureStats = (
                     } else {
                         finalActionDamage = (calculated.Damage || 0) + damageMod;
                     }
+                    finalActionDamage = Math.ceil(finalActionDamage);
                 }
 
                 let costParts = [];
@@ -530,6 +535,7 @@ export const calculateCreatureStats = (
             } else {
                 finalActionDamage = (finalCalcs.Damage || 0) + (damageMod || 0);
             }
+            finalActionDamage = Math.ceil(finalActionDamage);
         }
 
         let costParts = [];


### PR DESCRIPTION
## Summary
- round base damage and action damage up to the next integer
- adjust tests to expect rounded damage values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a860949c833196bc53c7434b1451