### PR TITLE
Fix html2canvas resolution for Vite builds

### DIFF
--- a/dc20-creature-creator/vite.config.js
+++ b/dc20-creature-creator/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      html2canvas: 'html2canvas/dist/html2canvas.esm.js',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- configure Vite to resolve the html2canvas module to its ESM build to ensure compatibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dce5d95adc8331a5f10d3af41d382e