### PR TITLE
Modularize creature stat calculation pipeline

### DIFF
--- a/dc20-creature-creator/src/components/StatBlockPanel.jsx
+++ b/dc20-creature-creator/src/components/StatBlockPanel.jsx
@@ -11,13 +11,17 @@ import {
 } from 'react-icons/gi';
 
 const StatBlockPanel = forwardRef(({ fullStatBlock, onStatOverride, onRemoveFeature, onActionUpdate, onDefaultActionUpdate }, ref) => {
-    if (!fullStatBlock || !fullStatBlock.Display || !fullStatBlock.CalculatedBeforeDeltas || !fullStatBlock.FinalWithDeltas) {
+    const raw = fullStatBlock?.raw;
+    const display = fullStatBlock?.display;
+    const derived = fullStatBlock?.derived;
+    const baseSnapshot = derived?.snapshots?.beforeOverrides;
+
+    if (!raw || !display || !baseSnapshot) {
         return <div className="stat-block-panel" ref={ref}><p>Calculating stats...</p></div>;
     }
 
-    const { Name, Level, Type, Role, Power } = fullStatBlock; // Root level info
-    const display = fullStatBlock.Display; // Convenience alias
-    const finalRaw = fullStatBlock.FinalWithDeltas; // For finding original features for removal
+    const { Name, Level, Type, Role, Power } = raw; // Root level info
+    const finalRaw = raw; // For finding original features for removal
 
     const getEditableNumericValue = (statString) => {
         if (typeof statString === 'string') {
@@ -33,9 +37,9 @@ const StatBlockPanel = forwardRef(({ fullStatBlock, onStatOverride, onRemoveFeat
     // It will then call App.jsx's onStatOverride to calculate the delta
     const handleSave = (fieldName, newAbsoluteValueFromInput) => {
         // App.jsx's onStatOverride needs: fieldName, newAbsoluteValue, originalCalculatedValue
-        // We get originalCalculatedValue from fullStatBlock.CalculatedBeforeDeltas
+        // We get originalCalculatedValue from the snapshot prior to overrides
         let originalCalcValue;
-        const baseObjectForDelta = fullStatBlock.CalculatedBeforeDeltas;
+        const baseObjectForDelta = baseSnapshot;
         const pathParts = fieldName.split('_');
         let tempOriginalValue = baseObjectForDelta;
 
@@ -241,25 +245,43 @@ const StatBlockPanel = forwardRef(({ fullStatBlock, onStatOverride, onRemoveFeat
                         </div>
                     ))}
 
-                    {finalRaw.CombatActions && finalRaw.CombatActions.filter(a => a.actionType && (a.actionType.includes('Attack') || a.actionType.includes('Spell'))).map((act, idx) => (
-                        <div key={act.originalFeatureId || `attack-${idx}`} className="sb-list-item attack-item">
-                            <ActionInlineDisplay
-                                action={{ ...act, details: act.details || act.displayDescription }}
-                                onSaveField={(field, val) => handleActionFieldSave(idx, field, val)}
-                            />
-                            {act.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(act)} />}
-                        </div>
-                    ))}
+                    {finalRaw.CombatActions && finalRaw.CombatActions.filter(a => a.actionType && (a.actionType.includes('Attack') || a.actionType.includes('Spell'))).map((act, idx) => {
+                        const displayAction = display.Combat.Attacks.find(a => a.originalFeatureId === act.originalFeatureId);
+                        const derivedAction = derived?.combatActions?.find(a => a.originalFeatureId === act.originalFeatureId);
+                        return (
+                            <div key={act.originalFeatureId || `attack-${idx}`} className="sb-list-item attack-item">
+                                <ActionInlineDisplay
+                                    action={{
+                                        ...act,
+                                        damage: derivedAction?.calculatedDamage ?? act.damage,
+                                        calculatedDamage: derivedAction?.calculatedDamage,
+                                        details: displayAction?.details,
+                                    }}
+                                    onSaveField={(field, val) => handleActionFieldSave(idx, field, val)}
+                                />
+                                {act.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(act)} />}
+                            </div>
+                        );
+                    })}
 
-                    {finalRaw.CombatActions && finalRaw.CombatActions.filter(a => !a.actionType || !(a.actionType.includes('Attack') || a.actionType.includes('Spell'))).map((act, idx) => (
-                        <div key={act.originalFeatureId || `action-${idx}`} className="sb-list-item action-item">
-                            <ActionInlineDisplay
-                                action={{ ...act, details: act.details || act.displayDescription }}
-                                onSaveField={(field, val) => handleActionFieldSave(idx, field, val)}
-                            />
-                            {act.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(act)} />}
-                        </div>
-                    ))}
+                    {finalRaw.CombatActions && finalRaw.CombatActions.filter(a => !a.actionType || !(a.actionType.includes('Attack') || a.actionType.includes('Spell'))).map((act, idx) => {
+                        const displayAction = display.Combat.OtherActions.find(a => a.originalFeatureId === act.originalFeatureId);
+                        const derivedAction = derived?.combatActions?.find(a => a.originalFeatureId === act.originalFeatureId);
+                        return (
+                            <div key={act.originalFeatureId || `action-${idx}`} className="sb-list-item action-item">
+                                <ActionInlineDisplay
+                                    action={{
+                                        ...act,
+                                        details: displayAction?.details,
+                                        damage: derivedAction?.calculatedDamage ?? act.damage,
+                                        calculatedDamage: derivedAction?.calculatedDamage,
+                                    }}
+                                    onSaveField={(field, val) => handleActionFieldSave(idx, field, val)}
+                                />
+                                {act.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(act)} />}
+                            </div>
+                        );
+                    })}
                 </div>
             }
 

--- a/dc20-creature-creator/src/domain/creatureBuilder.js
+++ b/dc20-creature-creator/src/domain/creatureBuilder.js
@@ -85,7 +85,7 @@ export const applyOverrides = (creatureState, overrides = {}, actionOverrides = 
 });
 
 const createDisplayActions = (statBlock, selectedFeatures = []) => {
-  const defaultActions = (statBlock?.FinalWithDeltas?.DefaultAttacks || []).map((attack) => ({
+  const defaultActions = (statBlock?.raw?.DefaultAttacks || []).map((attack) => ({
     name: attack.name,
     costAP: attack.costAP || 0,
     costMP: attack.costMP || 0,
@@ -94,7 +94,7 @@ const createDisplayActions = (statBlock, selectedFeatures = []) => {
     range: attack.range || '',
     targets: attack.targetDescription || '',
     actionType: attack.type || '',
-    description: attack.details || '',
+    description: '',
     source: 'default',
   }));
 

--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
@@ -154,8 +154,9 @@ const CreatureCreatorPage = ({ currentUser }) => {
   };
 
   const handleStatOverride = (fieldName, newAbsoluteValueFromInput) => {
-    if (!statBlock || !statBlock.CalculatedBeforeDeltas) {
-      console.error('Cannot calculate delta: statBlock.CalculatedBeforeDeltas is not available.');
+    const baseObjectForDelta = statBlock?.derived?.snapshots?.beforeOverrides;
+    if (!baseObjectForDelta) {
+      console.error('Cannot calculate delta: statBlock.derived.snapshots.beforeOverrides is not available.');
       dispatch({
         type: 'SET_OVERRIDES',
         payload: { ...overrides, [`${fieldName}_set`]: newAbsoluteValueFromInput },
@@ -163,7 +164,6 @@ const CreatureCreatorPage = ({ currentUser }) => {
       return;
     }
 
-    const baseObjectForDelta = statBlock.CalculatedBeforeDeltas;
     const pathParts = fieldName.split('_');
 
     let originalValueForDeltaCalc;
@@ -193,7 +193,7 @@ const CreatureCreatorPage = ({ currentUser }) => {
     const updatedOverrides = { ...overrides };
 
     if (typeof originalValueForDeltaCalc === 'undefined') {
-      console.warn(`Cannot find original value for delta for field: "${fieldName}" in CalculatedBeforeDeltas. Storing as absolute set.`);
+      console.warn(`Cannot find original value for delta for field: "${fieldName}" in base snapshot. Storing as absolute set.`);
       updatedOverrides[`${fieldName}_set`] = newAbsoluteValueFromInput;
       dispatch({ type: 'SET_OVERRIDES', payload: updatedOverrides });
       return;

--- a/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
+++ b/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
@@ -13,7 +13,7 @@ describe('calculateCreatureStats', () => {
     };
 
     const result = calculateCreatureStats(inputs, [], {});
-    const final = result.FinalWithDeltas;
+    const final = result.raw;
 
     expect(final).toBeDefined();
     expect(final.HP).toBe(10);
@@ -26,10 +26,10 @@ describe('calculateCreatureStats', () => {
     expect(final.MaxMP).toBe(0);
     expect(final.Attributes).toEqual({ Mig: 3, Agi: 2, Cha: 1, Int: -2, Prime: 3 });
     expect(final.Saves).toEqual({ Mig: 4, Agi: 3, Cha: 2, Int: -1 });
-    expect(result.Display.PD).toBe('12 (17/22)');
-    expect(result.Display.Combat.Check).toBe('+4');
-    expect(result.Display.Combat.AP).toBe('4');
-    expect(result.Display.Combat.Speed).toBe('5');
+    expect(result.display.PD).toBe('12 (17/22)');
+    expect(result.display.Combat.Check).toBe('+4');
+    expect(result.display.Combat.AP).toBe('4');
+    expect(result.display.Combat.Speed).toBe('5');
   });
 
 
@@ -60,7 +60,7 @@ describe('calculateCreatureStats', () => {
     };
 
     const result = calculateCreatureStats(inputs, [action], {});
-    const displayAttack = result.Display.Combat.Attacks.find(a => a.name.startsWith('Fiery Strike'));
+    const displayAttack = result.display.Combat.Attacks.find(a => a.name.startsWith('Fiery Strike'));
     expect(displayAttack).toBeDefined();
     expect(displayAttack.details).toContain('4 fire damage vs PD.');
     expect(displayAttack.details).toContain('DC 16');
@@ -87,8 +87,8 @@ describe('calculateCreatureStats', () => {
 
     const result = calculateCreatureStats(inputs, [], {}, actionOverrides);
 
-    expect(result.FinalWithDeltas.DefaultAttacks[0].damage).toBe(8);
-    const displayAttack = result.Display.Combat.Attacks[0];
+    expect(result.raw.DefaultAttacks[0].damage).toBe(8);
+    const displayAttack = result.display.Combat.Attacks[0];
     expect(displayAttack.name).toBe('Custom Attack');
     expect(displayAttack.details).toContain('8 physical damage');
   });
@@ -116,9 +116,9 @@ describe('calculateCreatureStats', () => {
     };
 
     const result = calculateCreatureStats(inputs, [apexAction], {});
-    expect(result.FinalWithDeltas.LAP).toBe(3);
-    expect(result.Display.Combat.LAP).toBe('3');
-    const aa = result.Display.ApexActions.find(a => a.name.startsWith('Tail Sweep'));
+    expect(result.raw.LAP).toBe(3);
+    expect(result.display.Combat.LAP).toBe('3');
+    const aa = result.display.ApexActions.find(a => a.name.startsWith('Tail Sweep'));
     expect(aa).toBeDefined();
     expect(aa.details).toContain('Swipe your tail');
   });

--- a/dc20-creature-creator/src/utils/baseStats.js
+++ b/dc20-creature-creator/src/utils/baseStats.js
@@ -1,0 +1,231 @@
+import {
+  baseLevelStatsData,
+  attributeScoresByLevel,
+  roleModifiersData,
+  powerScalingFactors,
+} from '../data/gameRules';
+
+export const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
+
+const sizeOrder = ['tiny', 'small', 'medium', 'large', 'huge', 'gargantuan'];
+
+const getInitialStats = (inputs) => {
+  const {
+    level = 1,
+    power = 'normal',
+    role = 'none',
+    type = 'beast',
+    size = 'medium',
+    creatureName,
+  } = inputs || {};
+
+  return {
+    Name: creatureName || 'Unnamed Creature',
+    Level: level,
+    Power: power,
+    Type: type,
+    Role: role,
+    Size: size,
+    HP: 0,
+    PD: 0,
+    AD: 0,
+    Check: 0,
+    Damage: 0,
+    AP: 0,
+    LAP: 0,
+    Speed: 0,
+    MaxMP: 0,
+    Attributes: { Mig: 0, Agi: 0, Cha: 0, Int: 0, Prime: 0 },
+    Saves: { Mig: null, Agi: null, Cha: null, Int: null },
+    Skills: {},
+    Resistances: [],
+    Vulnerabilities: [],
+    Immunities: [],
+    Senses: [],
+    Languages: [],
+    Features: [],
+    CombatActions: [],
+    ApexActions: [],
+    Reactions: [],
+    AttackEnhancements: [],
+    PDR: '',
+    Range: 'Melee',
+    isCaster: false,
+    isMartial: true,
+    SaveDC: 10,
+    DefaultAttacks: [],
+  };
+};
+
+const applyLevelBase = (stats, levelBase) => {
+  const working = stats;
+  working.HP = levelBase.HP || 0;
+  working.PD = levelBase.PD || 0;
+  working.AD = levelBase.AD || 0;
+  working.Check = levelBase.Check || 0;
+  working.Damage = levelBase.Damage || 0;
+  working.AP = levelBase.AP || 0;
+  working.Speed = levelBase.Speed || 0;
+  working.MaxMP = levelBase.MaxMP || 0;
+  return working;
+};
+
+const applyRoleModifiers = (stats, roleMods, levelBase) => {
+  const working = stats;
+  working.HP = Math.round(working.HP * (roleMods.HPFactor || 1));
+  working.PD += roleMods.PDMod || 0;
+  working.AD += roleMods.ADMod || 0;
+  working.Check += roleMods.CheckMod || 0;
+  working.Damage += roleMods.DamageMod || 0;
+  working.Speed += roleMods.SpeedMod || 0;
+  working.MaxMP = (levelBase.MaxMP || 0) + (roleMods.MPMod || 0);
+  if (roleMods.Range) {
+    working.Range = roleMods.Range;
+  }
+  working.isCaster = !!roleMods.isCaster;
+  working.isMartial = !working.isCaster;
+  return working;
+};
+
+const applyPowerScaling = (stats, powerScale) => {
+  const working = stats;
+  working.HP = Math.round(working.HP * (powerScale.HP || 1));
+  working.PD += powerScale.Defense || 0;
+  working.AD += powerScale.Defense || 0;
+  working.Check += powerScale.Check || 0;
+  working.Damage += powerScale.Damage || 0;
+  working.AP += powerScale.AP || 0;
+  working.MaxMP = Math.ceil(working.MaxMP * (powerScale.MP || 1));
+  working.SaveDC = 10 + (powerScale.SaveDC || 0);
+  return working;
+};
+
+const applySizeAdjustments = (stats, size) => {
+  const working = stats;
+  const sizeIndex = sizeOrder.indexOf((size || 'medium').toLowerCase());
+  const mediumIndex = sizeOrder.indexOf('medium');
+  if (sizeIndex !== -1 && mediumIndex !== -1) {
+    const sizeDelta = sizeIndex - mediumIndex;
+    working.AD += sizeDelta;
+    working.PD -= sizeDelta;
+  }
+  return working;
+};
+
+const assignAttributes = (stats, level, roleMods) => {
+  const working = stats;
+  const attributeLevelScores =
+    attributeScoresByLevel.find((entry) => entry.level === level)?.scores || [0, 0, 0, 0];
+
+  if (roleMods.AttributePriority) {
+    roleMods.AttributePriority.forEach((attrName, index) => {
+      if (Object.prototype.hasOwnProperty.call(working.Attributes, attrName)) {
+        working.Attributes[attrName] = attributeLevelScores[index];
+      }
+    });
+  }
+
+  return working;
+};
+
+const assignSkills = (stats, level, roleMods) => {
+  const working = stats;
+  working.Skills = {};
+  const getAttributeForSkill = (skillName, attrs) => {
+    if (skillName === 'awareness') {
+      const primeAttr = roleMods.AttributePriority?.[0];
+      return primeAttr ? attrs[primeAttr] || 0 : attrs.Prime || 0;
+    }
+    if (['athletics', 'intimidation'].includes(skillName)) return attrs.Mig || 0;
+    if (['acrobatics', 'trickery', 'stealth'].includes(skillName)) return attrs.Agi || 0;
+    if (['animal handling', 'influence', 'insight'].includes(skillName)) return attrs.Cha || 0;
+    return attrs.Int || 0;
+  };
+
+  if (roleMods.Skills) {
+    roleMods.Skills.forEach((skillName) => {
+      if (typeof skillName === 'string' && skillName.length > 0) {
+        const skillBonusFromLevel = Math.ceil(level / 5) * 2;
+        const attributeValue = getAttributeForSkill(skillName, working.Attributes);
+        working.Skills[skillName] = skillBonusFromLevel + attributeValue;
+      }
+    });
+  }
+
+  return working;
+};
+
+export const calculateBaseStats = (inputs = {}) => {
+  const normalizedInputs = {
+    ...inputs,
+    power: typeof inputs.power === 'string' ? inputs.power.toLowerCase() : 'normal',
+    role: typeof inputs.role === 'string' ? inputs.role.toLowerCase() : 'none',
+    size: typeof inputs.size === 'string' ? inputs.size.toLowerCase() : 'medium',
+  };
+
+  const stats = getInitialStats(normalizedInputs);
+  const levelBase = baseLevelStatsData.find((entry) => entry.level === stats.Level);
+
+  if (!levelBase) {
+    console.error(`No base stats for level ${stats.Level}`);
+    return {
+      stats,
+      context: {
+        roleMods: roleModifiersData.none,
+        powerScale: powerScalingFactors.normal,
+        levelBase: null,
+      },
+    };
+  }
+
+  applyLevelBase(stats, levelBase);
+
+  const roleMods = roleModifiersData[stats.Role] || roleModifiersData.none;
+  applyRoleModifiers(stats, roleMods, levelBase);
+
+  const powerScale = powerScalingFactors[stats.Power] || powerScalingFactors.normal;
+  applyPowerScaling(stats, powerScale);
+
+  applySizeAdjustments(stats, stats.Size);
+  assignAttributes(stats, stats.Level, roleMods);
+  assignSkills(stats, stats.Level, roleMods);
+
+  stats.LAP =
+    stats.Power === 'apex' ? 3 : stats.Power === 'legendary' ? 6 : 0;
+
+  return {
+    stats,
+    context: {
+      roleMods,
+      powerScale,
+      levelBase,
+    },
+  };
+};
+
+export const finalizeDerivedValues = (stats, context) => {
+  const working = stats;
+  const { roleMods, powerScale } = context;
+
+  if (roleMods.AttributePriority) {
+    const prime = roleMods.AttributePriority[0];
+    working.Attributes.Prime = working.Attributes[prime] || 0;
+  }
+
+  working.Damage = Math.ceil(working.Damage);
+
+  const CM_final = Math.ceil(working.Level / 2);
+  working.Saves = { Mig: null, Agi: null, Cha: null, Int: null };
+  if (roleMods.SavesProficient) {
+    roleMods.SavesProficient.forEach((attr) => {
+      if (Object.prototype.hasOwnProperty.call(working.Attributes, attr)) {
+        working.Saves[attr] = (working.Attributes[attr] || 0) + CM_final;
+      }
+    });
+  }
+
+  working.SaveDC =
+    10 + (working.Attributes.Prime || 0) + CM_final + (powerScale?.SaveDC || 0);
+
+  return working;
+};

--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -1,646 +1,185 @@
-// src/utils/calculateStats.js
-import {
-    baseLevelStatsData,
-    attributeScoresByLevel,
-    roleModifiersData,
-    powerScalingFactors
-} from '../data/gameRules';
+import { calculateBaseStats, deepClone, finalizeDerivedValues } from './baseStats';
+import { applyFeatureEffects, buildDefaultAttacks } from './featureEffects';
+import { applyDefaultActionOverrides, applyUserOverrides } from './overrideApplier';
+import { formatForPresentation } from './presentationFormatter';
 
-const deepClone = (obj) => JSON.parse(JSON.stringify(obj));
+const isAttackAction = (action) => {
+  if (!action || typeof action.actionType !== 'string') return false;
+  const type = action.actionType.toLowerCase();
+  return type.includes('attack') || type.includes('spell');
+};
 
-export const calculateCreatureStats = (
-    inputs,
-    selectedRawFeatures,
-    userOverrideDeltas = {},
-    defaultActionOverrides = {},
-    actions = []
-) => {
-    const { level, power, role, type, size, creatureName } = inputs;
+const enhanceActionData = (rawStats, actions = []) =>
+  actions.map((action) => {
+    const calculatedDamage = (() => {
+      if (typeof action.baseDamageOverride === 'number') {
+        return action.baseDamageOverride + (action.damageMod || 0);
+      }
+      if (!isAttackAction(action)) {
+        return 0;
+      }
+      return rawStats.Damage + (action.damageMod || 0);
+    })();
 
-    let calculated = {
-        Name: creatureName || "Unnamed Creature",
-        Level: level, Power: power, Type: type, Role: role, Size: size,
-        HP: 0, PD: 0, AD: 0, Check: 0, Damage: 0, AP: 0, LAP: 0, Speed: 0, MaxMP: 0,
-        Attributes: { Mig: 0, Agi: 0, Cha: 0, Int: 0, Prime: 0 },
-        Saves: { Mig: null, Agi: null, Cha: null, Int: null },
-        Skills: {}, Resistances: [], Vulnerabilities: [], Immunities: [],
-        Senses: [], Languages: [], Features: [], CombatActions: [],
-        ApexActions: [], Reactions: [], AttackEnhancements: [], PDR: '', Range: "Melee",
-        isCaster: false, isMartial: true, SaveDC: 10, DefaultAttacks: [],
-    };
+    const calculatedSaveDC = rawStats.SaveDC + (action.saveDCMod || 0);
 
-    // --- 1. Get Base Stats from Level ---
-    const levelBase = baseLevelStatsData.find(l => l.level === level);
-    if (!levelBase) {
-        console.error(`No base stats for level ${level}`);
-        return { Name: calculated.Name, Level: level, CalculatedBeforeDeltas: calculated, FinalWithDeltas: calculated, Display: {} };
-    }
-    calculated.HP = levelBase.HP || 0;
-    calculated.PD = levelBase.PD || 0;
-    calculated.AD = levelBase.AD || 0;
-    calculated.Check = levelBase.Check || 0;
-    calculated.Damage = levelBase.Damage || 0;
-    calculated.AP = levelBase.AP || 0;
-    calculated.Speed = levelBase.Speed || 0;
-    // MaxMP from levelBase is likely 0, role will provide the true base
-
-    // --- 3. Apply Role Modifiers (Part 1: Get base values including MaxMP from role) ---
-    const roleMods = roleModifiersData[role] || roleModifiersData.none;
-    calculated.HP = Math.round(calculated.HP * (roleMods.HPFactor || 1.0));
-    calculated.PD += roleMods.PDMod || 0;
-    calculated.AD += roleMods.ADMod || 0;
-    calculated.Check += roleMods.CheckMod || 0;
-    calculated.Damage += roleMods.DamageMod || 0;
-    calculated.Speed += roleMods.SpeedMod || 0;
-    calculated.MaxMP = (levelBase.MaxMP || 0) + (roleMods.MPMod || 0); // Role grants base MP
-    if (roleMods.Range) calculated.Range = roleMods.Range;
-    calculated.isCaster = !!roleMods.isCaster;
-    calculated.isMartial = !calculated.isCaster;
-
-    // --- 2. Apply Power Scaling (AFTER role gives base MP) ---
-    const powerScale = powerScalingFactors[power] || powerScalingFactors.normal;
-    if (powerScale) {
-        calculated.HP = Math.round(calculated.HP * (powerScale.HP || 1)); // HP scaling can happen here or after role, be consistent
-        calculated.PD += powerScale.Defense || 0;
-        calculated.AD += powerScale.Defense || 0;
-        calculated.Check += powerScale.Check || 0;
-        //SAVE DCs are done below, as it gets overwritten if stated here.
-        calculated.Damage += powerScale.Damage || 0;
-        calculated.AP += powerScale.AP || 0;
-        // Apply power scaling to MaxMP (Role MP * Power Factor)
-        calculated.MaxMP = Math.ceil(calculated.MaxMP * (powerScale.MP || 1)); // Use MP for key, ceil the result
-    } else {
-        console.warn(`Power scale not found for: ${power}.`);
-    }
-
-    calculated.LAP = power === 'apex' ? 3 : power === 'legendary' ? 6 : 0;
-
-    // --- 2.5. Apply Size-Based Defense/Attack Modifiers ---
-    // For each size step above medium: AD +1, PD -1; for each below: AD -1, PD +1
-    const sizeOrder = ['tiny', 'small', 'medium', 'large', 'huge', 'gargantuan'];
-    const sizeIndex = sizeOrder.indexOf((size || 'medium').toLowerCase());
-    const mediumIndex = sizeOrder.indexOf('medium');
-    if (sizeIndex !== -1 && mediumIndex !== -1) {
-        const sizeDelta = sizeIndex - mediumIndex;
-        calculated.AD += sizeDelta;
-        calculated.PD -= sizeDelta;
-    }
-
-    // --- 4. Determine Attributes (Initial Calculation) ---
-    const attributeLevelScores = attributeScoresByLevel.find(a => a.level === level)?.scores || [0, 0, 0, 0];
-    if (roleMods.AttributePriority) {
-        roleMods.AttributePriority.forEach((attrName, index) => {
-            if (Object.prototype.hasOwnProperty.call(calculated.Attributes, attrName)) {
-                calculated.Attributes[attrName] = attributeLevelScores[index];
-            }
-        });
-    }
-
-    // --- 5. Calculate Skills (Initial Calculation) ---
-    const getAttributeForSkill = (skillName, attrs) => {
-        if (skillName === "awareness") {
-            const primeAttr = roleMods.AttributePriority?.[0];
-            return primeAttr ? (attrs[primeAttr] || 0) : (attrs.Prime || 0);
-        }
-        if (["athletics", "intimidation"].includes(skillName)) return attrs.Mig || 0;
-        if (["acrobatics", "trickery", "stealth"].includes(skillName)) return attrs.Agi || 0;
-        if (["animal handling", "influence", "insight"].includes(skillName)) return attrs.Cha || 0;
-        return attrs.Int || 0;
-    };
-    if (roleMods.Skills) {
-        roleMods.Skills.forEach(skillName => {
-            if (typeof skillName === 'string' && skillName.length > 0) {
-                const skillBonusFromLevel = Math.ceil(level / 5) * 2;
-                const attributeValue = getAttributeForSkill(skillName, calculated.Attributes);
-                calculated.Skills[skillName] = skillBonusFromLevel + attributeValue;
-            }
-        });
-    }
-
-    // --- Step 5.5: Apply Direct Stat Effects from *Selected Features* ---
-    selectedRawFeatures.forEach(feature => {
-        if (feature.category === 'feature' && Array.isArray(feature.effects)) {
-            feature.effects.forEach(effect => {
-                const { stat, change, value } = effect;
-                if (Object.prototype.hasOwnProperty.call(calculated, stat)) {
-                    if (change === 'add' && typeof value === 'number') calculated[stat] = (calculated[stat] || 0) + value;
-                    else if (change === 'set') calculated[stat] = value;
-                } else if (Object.prototype.hasOwnProperty.call(calculated.Attributes, stat)) {
-                    if (change === 'add' && typeof value === 'number') calculated.Attributes[stat] = (calculated.Attributes[stat] || 0) + value;
-                } else if (stat === 'PDR' && change === 'set') calculated.PDR = value;
-                else if (stat === 'MaxMP' && change === 'add' && typeof value === 'number') calculated.MaxMP = (calculated.MaxMP || 0) + value;
-            });
-        }
-    });
-
-
-    // --- Create a snapshot of stats AFTER features, BEFORE user deltas ---
-    const statsAfterFeatures = deepClone(calculated);
-
-
-    // --- Step 5.75: Apply User Override DELTAS (and SETS) ---
-    const attackOverrides = [];
-    for (const fullOverrideKey in userOverrideDeltas) {
-        if (Object.prototype.hasOwnProperty.call(userOverrideDeltas, fullOverrideKey)) {
-            const overrideStoredValue = userOverrideDeltas[fullOverrideKey];
-            const attackMatch = fullOverrideKey.match(/^Combat_Attacks_(\d+)_(.+)_(delta|set)$/);
-            if (attackMatch) {
-                const [, idxStr, field, type] = attackMatch;
-                attackOverrides.push({ index: parseInt(idxStr, 10), field, type, value: overrideStoredValue });
-                continue;
-            }
-
-            const parts = fullOverrideKey.split('_'); const suffix = parts.pop(); const fieldKey = parts.join('_');
-            const [mainKey, subKey] = fieldKey.split('_'); // Re-split fieldKey for nested access
-            if (suffix === 'delta' && typeof overrideStoredValue === 'number') {
-                if (subKey && calculated[mainKey] && typeof calculated[mainKey][subKey] === 'number') {
-                    calculated[mainKey][subKey] = (calculated[mainKey][subKey] || 0) + overrideStoredValue;
-                } else if (Object.prototype.hasOwnProperty.call(calculated, mainKey) && typeof calculated[mainKey] === 'number') {
-                    calculated[mainKey] = (calculated[mainKey] || 0) + overrideStoredValue;
-                }
-            } else if (suffix === 'set') {
-                // For nested _set like Attributes_Mig_set, fieldKey is Attributes_Mig, mainKey=Attributes, subKey=Mig
-                // For simple _set like Name_set, fieldKey is Name, mainKey=Name, subKey=undefined
-                if (subKey && Object.prototype.hasOwnProperty.call(calculated, mainKey) && typeof calculated[mainKey] === 'object' && calculated[mainKey] !== null) {
-                    calculated[mainKey][subKey] = overrideStoredValue;
-                } else if (Object.prototype.hasOwnProperty.call(calculated, fieldKey)) { // Use fieldKey for top-level like Name_set
-                    calculated[fieldKey] = overrideStoredValue;
-                } else {
-                    console.warn(`Cannot apply _set override for unhandled field structure: ${fullOverrideKey}`);
-                }
-            }
-        }
-    }
-    if (roleMods.AttributePriority) calculated.Attributes.Prime = calculated.Attributes[roleMods.AttributePriority[0]] || 0;
-
-    // Round up final damage after all base modifications and user overrides
-    calculated.Damage = Math.ceil(calculated.Damage);
-
-
-    // --- Recalculate Dependent Values (Saves, SaveDC) AFTER all modifications ---
-    const CM_final = Math.ceil(calculated.Level / 2);
-    calculated.Saves = { Mig: null, Agi: null, Cha: null, Int: null };
-    if (roleMods.SavesProficient) {
-        roleMods.SavesProficient.forEach(proficientAttrName => {
-            if (Object.prototype.hasOwnProperty.call(calculated.Attributes, proficientAttrName)) {
-                calculated.Saves[proficientAttrName] = (calculated.Attributes[proficientAttrName] || 0) + CM_final;
-            }
-        });
-    }
-    calculated.SaveDC = 10 + (calculated.Attributes.Prime || 0) + CM_final + powerScale.SaveDC;
-
-
-    // --- 6. Process Selected Features into Display Categories & CONSTRUCT Action/Attack Descriptions ---
-    calculated.Resistances = []; calculated.Vulnerabilities = []; calculated.Immunities = [];
-    calculated.Senses = []; calculated.Languages = []; calculated.Features = [];
-    calculated.CombatActions = []; calculated.AttackEnhancements = []; calculated.Reactions = [];
-
-    selectedRawFeatures.forEach(feature => {
-        const { id, name, category, originalFeatureId,
-            descriptionCore, costAP = 0, costMP = 0, // costSP = 0,
-            actionType, damageMod = 0, damageType, targetsDefense,
-            rangeValue = 0, rangeUnit, areaShape, areaSize, targetDescription,
-            saveAttribute, saveDCMod = 0, conditionApplied, conditionDuration, healingAmount,
-            description, value, displayValue } = feature; // Removed 'effects' as it's processed earlier
-
-        switch (category) {
-            case 'feature':
-                calculated.Features.push({ name, description: descriptionCore || description, originalFeatureId: id || originalFeatureId });
-                break;
-            case 'action': {
-                let finalActionDamage = 0;
-                if (actionType && (actionType.includes("Attack") || actionType.includes("Spell"))) {
-                    if (typeof feature.baseDamageOverride === 'number') {
-                        finalActionDamage = feature.baseDamageOverride + damageMod;
-                    } else {
-                        finalActionDamage = (calculated.Damage || 0) + damageMod;
-                    }
-                    finalActionDamage = Math.ceil(finalActionDamage);
-                }
-
-                let costParts = [];
-                if (costAP > 0) costParts.push(`${costAP} AP`);
-                if (costMP > 0) costParts.push(`${costMP} MP`);
-                let displayCostStr = costParts.join(' + ') || 'Free';
-                if (category === 'reaction' && !costParts.length) displayCostStr = 'Reaction';
-
-                let descDisplayParts = [];
-
-                if (finalActionDamage > 0) {
-                    descDisplayParts.push(`${finalActionDamage} ${damageType || 'damage'} damage${targetsDefense ? ` vs ${targetsDefense}` : ''}.`);
-                }
-                let targetInfo = targetDescription || (areaShape ? (areaSize ? `${areaSize}-space ${areaShape}` : areaShape) : 'target');
-
-                let rangeInfo = '';
-                if (rangeValue > 0 && rangeUnit === 'space') {
-                    rangeInfo = `${rangeValue} space(s)`;
-                } else if (rangeUnit) {
-                    rangeInfo = rangeUnit.charAt(0).toUpperCase() + rangeUnit.slice(1);
-                }
-                if (targetInfo || rangeInfo) {
-                    descDisplayParts.push(`Target ${targetInfo}${rangeInfo ? ` within ${rangeInfo}` : ''}.`);
-                }
-
-                if (saveAttribute) {
-                    const finalActionSaveDC = (calculated.SaveDC || 0) + (saveDCMod || 0);
-                    let saveStr = `Target makes a ${saveAttribute} save (DC ${finalActionSaveDC})`;
-                    saveStr += conditionApplied ? ` or becomes ${conditionApplied}` : ` for effect`;
-                    if (conditionApplied && conditionDuration) saveStr += ` (${conditionDuration.replace("your", "its")})`;
-                    descDisplayParts.push(saveStr + ".");
-                } else if (conditionApplied) {
-                    let condStr = `Applies ${conditionApplied}`;
-                    if (conditionDuration) condStr += ` (${conditionDuration.replace("your", "its")})`;
-                    descDisplayParts.push(condStr + ".");
-                }
-                if (healingAmount) descDisplayParts.push(healingAmount === "damage dealt" ? "You regain HP equal to damage dealt." : `Heals for ${healingAmount} HP.`);
-
-                if (descriptionCore || description) {
-                    descDisplayParts.push(descriptionCore || description);
-                } else if (!descDisplayParts.length && name) {
-                    descDisplayParts.push(name);
-                }
-
-                calculated.CombatActions.push({
-                    ...feature, name, calculatedDamage: finalActionDamage,
-                    calculatedSaveDC: (calculated.SaveDC || 0) + (saveDCMod || 0),
-                    displayCost: displayCostStr,
-                    displayDescription: descDisplayParts.filter(p => p && p.trim() !== '').join(' '),
-                    originalFeatureId: id || originalFeatureId
-                });
-                break;
-            }
-            case 'apex_action': {
-                let finalActionDamage = 0;
-                if (actionType && (actionType.includes("Attack") || actionType.includes("Spell"))) {
-                    if (typeof feature.baseDamageOverride === 'number') {
-                        finalActionDamage = feature.baseDamageOverride + damageMod;
-                    } else {
-                        finalActionDamage = (calculated.Damage || 0) + damageMod;
-                    }
-                    finalActionDamage = Math.ceil(finalActionDamage);
-                }
-
-                let costParts = [];
-                if (costAP > 0) costParts.push(`${costAP} AP`);
-                if (costMP > 0) costParts.push(`${costMP} MP`);
-                let displayCostStr = costParts.join(' + ') || 'Free';
-
-                let descDisplayParts = [];
-
-                if (finalActionDamage > 0) {
-                    descDisplayParts.push(`${finalActionDamage} ${damageType || 'damage'} damage${targetsDefense ? ` vs ${targetsDefense}` : ''}.`);
-                }
-                let targetInfo = targetDescription || (areaShape ? (areaSize ? `${areaSize}-space ${areaShape}` : areaShape) : 'target');
-
-                let rangeInfo = '';
-                if (rangeValue > 0 && rangeUnit === 'space') {
-                    rangeInfo = `${rangeValue} space(s)`;
-                } else if (rangeUnit) {
-                    rangeInfo = rangeUnit.charAt(0).toUpperCase() + rangeUnit.slice(1);
-                }
-                if (targetInfo || rangeInfo) {
-                    descDisplayParts.push(`Target ${targetInfo}${rangeInfo ? ` within ${rangeInfo}` : ''}.`);
-                }
-
-                if (saveAttribute) {
-                    const finalActionSaveDC = (calculated.SaveDC || 0) + (saveDCMod || 0);
-                    let saveStr = `Target makes a ${saveAttribute} save (DC ${finalActionSaveDC})`;
-                    saveStr += conditionApplied ? ` or becomes ${conditionApplied}` : ` for effect`;
-                    if (conditionApplied && conditionDuration) saveStr += ` (${conditionDuration.replace("your", "its")})`;
-                    descDisplayParts.push(saveStr + ".");
-                } else if (conditionApplied) {
-                    let condStr = `Applies ${conditionApplied}`;
-                    if (conditionDuration) condStr += ` (${conditionDuration.replace("your", "its")})`;
-                    descDisplayParts.push(condStr + ".");
-                }
-                if (healingAmount) descDisplayParts.push(healingAmount === "damage dealt" ? "You regain HP equal to damage dealt." : `Heals for ${healingAmount} HP.`);
-
-                if (descriptionCore || description) {
-                    descDisplayParts.push(descriptionCore || description);
-                } else if (!descDisplayParts.length && name) {
-                    descDisplayParts.push(name);
-                }
-
-                calculated.ApexActions.push({
-                    ...feature, name,
-                    calculatedDamage: finalActionDamage,
-                    calculatedSaveDC: (calculated.SaveDC || 0) + (saveDCMod || 0),
-                    cost: displayCostStr,
-                    displayDescription: descDisplayParts.filter(p => p && p.trim() !== '').join(' '),
-                    originalFeatureId: id || originalFeatureId
-                });
-                break;
-            }
-            case 'attack_enhancement':
-
-            {
-                let enhDescParts = [];
-                if (descriptionCore || description) {
-                    enhDescParts.push(descriptionCore || description);
-                } else if (name) {
-                    enhDescParts.push(name);
-                }
-
-                if (saveAttribute) {
-                    const enhSaveDC = (calculated.SaveDC || 0) + (saveDCMod || 0);
-                    enhDescParts.push(`Target makes a ${saveAttribute} save (DC ${enhSaveDC})`);
-                }
-                if (conditionApplied) {
-                    enhDescParts.push(
-                        conditionApplied
-                            ? `or becomes ${conditionApplied}${
-                                  conditionDuration
-                                      ? ` (${conditionDuration.replace("your", "its")})`
-                                      : ''
-                              }`
-                            : ''
-                    );
-                }
-                // description already added above
-                if (!enhDescParts.length && name) enhDescParts.push(name);
-                calculated.AttackEnhancements.push({
-                    ...feature,
-                    name,
-                    cost:
-                        costAP > 0
-                            ? `+${costAP} AP`
-                            : costMP > 0
-                            ? `+${costMP} MP`
-                            : 'Special',
-                    description: enhDescParts.filter(Boolean).join('. '),
-                    originalFeatureId: id || originalFeatureId,
-                });
-                break;
-            }
-            case 'reaction':
-                calculated.Reactions.push({ ...feature, name, cost: costAP > 0 ? `${costAP} AP` : 'Reaction', description: descriptionCore || description, originalFeatureId: id || originalFeatureId });
-                break;
-            case 'resistance': calculated.Resistances.push(displayValue || value || name); break;
-            case 'vulnerability': calculated.Vulnerabilities.push(displayValue || value || name); break;
-            case 'immunity': calculated.Immunities.push(displayValue || value || name); break;
-            case 'sense': calculated.Senses.push(displayValue || value || name); break;
-            case 'language': calculated.Languages.push(displayValue || value || name); break;
-            default: break;
-        }
-    });
-
-
-
-    // --- 7. Generate Default Attacks ---
-    // Uses the final `calculated.Damage` which includes base, power, role, feature effects, AND user deltas.
-    calculated.DefaultAttacks = [];
-    const currentFinalBaseDamage = calculated.Damage; // Base damage AFTER all modifications
-    const defaultAPCostMelee = 1;
-    const defaultAPCostRanged = 2;
-
-    // --- Default Melee Attack ---
-    let meleeAttackName = "Melee Attack";
-    let meleeAttackType = "Melee"; // Will be refined
-    let meleeDamageType = "physical"; // Default assumption
-    let meleeTargetsDefense = "PD";
-    let meleeAttackDetails = [];
-
-    // Base description part - "You make a [type] attack."
-    if (calculated.isMartial && calculated.isCaster) {
-        meleeAttackName = "Melee Attack (Martial or Spell)";
-        meleeAttackType = "Melee Hybrid";
-        meleeAttackDetails.push(`${currentFinalBaseDamage} damage (choose physical or magical type) vs ${meleeTargetsDefense}.`);
-    } else if (calculated.isMartial) {
-        meleeAttackName = "Melee Martial Attack";
-        meleeAttackType = "Melee Martial";
-        meleeDamageType = "physical";
-        meleeAttackDetails.push(`${currentFinalBaseDamage} ${meleeDamageType} damage vs ${meleeTargetsDefense}.`);
-    } else if (calculated.isCaster) {
-        meleeAttackName = "Melee Spell Attack";
-        meleeAttackType = "Melee Spell";
-        meleeDamageType = "magical"; // Or a default caster damage type
-        meleeAttackDetails.push(`${currentFinalBaseDamage} ${meleeDamageType} damage vs ${meleeTargetsDefense}.`);
-    } else { // Fallback
-        meleeAttackDetails.push(`${currentFinalBaseDamage} damage vs ${meleeTargetsDefense}.`);
-    }
-    meleeAttackDetails.push("Target 1 creature within 1 space."); // Standard melee reach
-
-    calculated.DefaultAttacks.push({
-        name: meleeAttackName,
-        costAP: defaultAPCostMelee,
-        details: "", // OLD: meleeAttackDetails.join(' '), // Join parts into a readable sentence
-        type: meleeAttackType,
-        damage: currentFinalBaseDamage,
-        damageType: meleeDamageType,
-        range: "1 space", // Consistent with "within 1 space"
-        targetsDefense: meleeTargetsDefense,
-        targetDescription: "1 creature"
-    });
-
-    // --- Default Ranged Attack (if applicable) ---
-    if (calculated.Range && calculated.Range.toLowerCase() !== 'melee' && calculated.Range.toLowerCase() !== 'touch' && calculated.Range.toLowerCase() !== 'reach') {
-        const rangedDamageModFromRole = roleMods?.DamageModRanged !== undefined ? roleMods.DamageModRanged : 0;
-        const rangedCreatureDamage = currentFinalBaseDamage + rangedDamageModFromRole + 1; // Ranged often +1 base
-
-        let rangedAttackName = "Ranged Attack";
-        let rangedAttackType = "Ranged";
-        let rangedDamageType = "physical";
-        let rangedTargetsDefense = "PD";
-        let rangedAttackDetails = [];
-
-        if (calculated.isMartial && calculated.isCaster) {
-            rangedAttackName = "Ranged Attack (Martial or Spell)";
-            rangedAttackType = "Ranged Hybrid";
-            rangedAttackDetails.push(`${rangedCreatureDamage} damage (choose physical or magical type) vs ${rangedTargetsDefense}.`);
-        } else if (calculated.isMartial) {
-            rangedAttackName = "Ranged Martial Attack";
-            rangedAttackType = "Ranged Martial";
-            rangedDamageType = "physical";
-            rangedAttackDetails.push(`${rangedCreatureDamage} ${rangedDamageType} damage vs ${rangedTargetsDefense}.`);
-        } else if (calculated.isCaster) {
-            rangedAttackName = "Ranged Spell Attack";
-            rangedAttackType = "Ranged Spell";
-            rangedDamageType = "magical";
-            rangedAttackDetails.push(`${rangedCreatureDamage} ${rangedDamageType} damage vs ${rangedTargetsDefense}.`);
-        } else {
-            rangedAttackDetails.push(`${rangedCreatureDamage} damage vs ${rangedTargetsDefense}.`);
-        }
-        rangedAttackDetails.push(`Target 1 creature within ${calculated.Range}.`); // Use the creature's defined range
-
-        calculated.DefaultAttacks.push({
-            name: rangedAttackName,
-            costAP: defaultAPCostRanged,
-            details: "", //OLD: rangedAttackDetails.join(' ') Was removed due to not being needed
-            type: rangedAttackType,
-            damage: rangedCreatureDamage,
-            damageType: rangedDamageType,
-            range: calculated.Range,
-            targetsDefense: rangedTargetsDefense,
-            targetDescription: "1 creature"
-        });
-    }
-
-
-    // --- Apply overrides to default attacks ---
-    Object.entries(defaultActionOverrides || {}).forEach(([idx, ovr]) => {
-        const i = parseInt(idx, 10);
-        if (!isNaN(i) && calculated.DefaultAttacks[i]) {
-            calculated.DefaultAttacks[i] = { ...calculated.DefaultAttacks[i], ...ovr };
-
-            /* OLD WAY
-              // Apply any pending overrides to generated default attacks
-              attackOverrides.forEach(ov => {
-                  const att = calculated.DefaultAttacks[ov.index];
-                  if (!att) return;
-                  if (ov.type === 'delta' && typeof ov.value === 'number' && typeof att[ov.field] === 'number') {
-                      att[ov.field] = (att[ov.field] || 0) + ov.value;
-                  } else if (ov.type === 'set') {
-                      att[ov.field] = ov.value;
-              */
-        }
-    });
-
-    // --- 8. Format for Display ---
-    const finalCalcs = calculated;
-    const formattedPD = `${finalCalcs.PD} (${finalCalcs.PD + 5}/${finalCalcs.PD + 10})`;
-    const formattedAD = `${finalCalcs.AD} (${finalCalcs.AD + 5}/${finalCalcs.AD + 10})`;
-    const skillsString = Object.entries(finalCalcs.Skills).map(([skill, bonus]) => `${skill.charAt(0).toUpperCase() + skill.slice(1)} ${bonus >= 0 ? '+' : ''}${bonus}`).join(', ') || 'None';
-
-    let displayAttacks = finalCalcs.DefaultAttacks.map(att => ({
-        name: att.name,
-        costAP: att.costAP,
-        costMP: att.costMP || 0,
-        details: att.details,
-        originalFeatureId: null,
-    })); // Default attacks don't have originalFeatureId from selectedFeatures
-    const specificAttackActions = finalCalcs.CombatActions.filter(ca => ca.actionType && (ca.actionType.includes("Attack") || ca.actionType.includes("Spell")));
-    specificAttackActions.forEach(ca => {
-        if (!displayAttacks.find(da => da.name === ca.name)) {
-            displayAttacks.push({
-                name: ca.name,
-                costAP: ca.costAP || 0,
-                costMP: ca.costMP || 0,
-                details: ca.displayDescription,
-                originalFeatureId: ca.originalFeatureId,
-            });
-        }
-    });
-    const otherDisplayCombatActions = finalCalcs.CombatActions.filter(ca => !ca.actionType || !(ca.actionType.includes("Attack") || ca.actionType.includes("Spell")))
-        .map(ca => ({ name: `${ca.name} (${ca.displayCost})`, details: ca.displayDescription, originalFeatureId: ca.originalFeatureId }));
-
-    const formattedActions = (actions || []).map(act => {
-        const { name, descriptionCore, description, costAP = 0, costMP = 0, actionType,
-            damageMod = 0, baseDamageOverride, damageType, targetsDefense, rangeValue = 0,
-            rangeUnit, areaShape, areaSize, targetDescription, saveAttribute, saveDCMod = 0,
-            conditionApplied, conditionDuration, healingAmount } = act;
-
-        let finalActionDamage = 0;
-        if (actionType && (actionType.includes('Attack') || actionType.includes('Spell'))) {
-            if (typeof baseDamageOverride === 'number') {
-                finalActionDamage = baseDamageOverride + (damageMod || 0);
-            } else {
-                finalActionDamage = (finalCalcs.Damage || 0) + (damageMod || 0);
-            }
-            finalActionDamage = Math.ceil(finalActionDamage);
-        }
-
-        let costParts = [];
-        if (costAP > 0) costParts.push(`${costAP} AP`);
-        if (costMP > 0) costParts.push(`${costMP} MP`);
-        const displayCostStr = costParts.join(' + ') || 'Free';
-
-        let descDisplayParts = [];
-        if (finalActionDamage > 0) {
-            descDisplayParts.push(`${finalActionDamage} ${damageType || 'damage'} damage${targetsDefense ? ` vs ${targetsDefense}` : ''}.`);
-        }
-        const targetInfo = targetDescription || (areaShape ? (areaSize ? `${areaSize}-space ${areaShape}` : areaShape) : 'target');
-        let rangeInfo = '';
-        if (rangeValue > 0 && rangeUnit === 'space') {
-            rangeInfo = `${rangeValue} space(s)`;
-        } else if (rangeUnit) {
-            rangeInfo = rangeUnit.charAt(0).toUpperCase() + rangeUnit.slice(1);
-        }
-        if (targetInfo || rangeInfo) {
-            descDisplayParts.push(`Target ${targetInfo}${rangeInfo ? ` within ${rangeInfo}` : ''}.`);
-        }
-
-        if (saveAttribute) {
-            const actionSaveDC = finalCalcs.SaveDC + (saveDCMod || 0);
-            let saveStr = `Target makes a ${saveAttribute} save (DC ${actionSaveDC})`;
-            saveStr += conditionApplied ? ` or becomes ${conditionApplied}` : ` for effect`;
-            if (conditionApplied && conditionDuration) saveStr += ` (${conditionDuration.replace("your", "its")})`;
-            descDisplayParts.push(saveStr + '.');
-        } else if (conditionApplied) {
-            let condStr = `Applies ${conditionApplied}`;
-            if (conditionDuration) condStr += ` (${conditionDuration.replace("your", "its")})`;
-            descDisplayParts.push(condStr + '.');
-        }
-        if (healingAmount) {
-            descDisplayParts.push(healingAmount === 'damage dealt' ? 'You regain HP equal to damage dealt.' : `Heals for ${healingAmount} HP.`);
-        }
-
-        if (descriptionCore || description) {
-            descDisplayParts.push(descriptionCore || description);
-        } else if (!descDisplayParts.length && name) {
-            descDisplayParts.push(name);
-        }
-
-        return {
-            name: `${name} (${displayCostStr})`,
-            details: descDisplayParts.filter(p => p && p.trim() !== '').join(' ')
-        };
-    });
+    const costParts = [];
+    if (action.costAP > 0) costParts.push(`${action.costAP} AP`);
+    if (action.costMP > 0) costParts.push(`${action.costMP} MP`);
+    const displayCost =
+      action.category === 'reaction' && costParts.length === 0
+        ? 'Reaction'
+        : costParts.join(' + ') || 'Free';
 
     return {
-        Name: finalCalcs.Name, Level: finalCalcs.Level, Power: finalCalcs.Power, Type: finalCalcs.Type, Role: finalCalcs.Role, Size: finalCalcs.Size,
-        CalculatedBeforeDeltas: statsAfterFeatures,
-        FinalWithDeltas: finalCalcs,
-        FormattedActions: formattedActions,
-        Display: {
-            HP: finalCalcs.HP, PD: formattedPD, AD: formattedAD,
-            MIG: `${finalCalcs.Attributes.Mig}${finalCalcs.Saves.Mig !== null ? ` (${finalCalcs.Saves.Mig})` : ''}`,
-            AGI: `${finalCalcs.Attributes.Agi}${finalCalcs.Saves.Agi !== null ? ` (${finalCalcs.Saves.Agi})` : ''}`,
-            CHA: `${finalCalcs.Attributes.Cha}${finalCalcs.Saves.Cha !== null ? ` (${finalCalcs.Saves.Cha})` : ''}`,
-            INT: `${finalCalcs.Attributes.Int}${finalCalcs.Saves.Int !== null ? ` (${finalCalcs.Saves.Int})` : ''}`,
-            MaxMP: finalCalcs.MaxMP > 0 ? finalCalcs.MaxMP.toString() : '', // Empty string if 0, or 'None'
-            PDR: finalCalcs.PDR || '', Skills: skillsString,
-            Resistant: finalCalcs.Resistances.join(', ') || 'None', Vulnerable: finalCalcs.Vulnerabilities.join(', ') || 'None',
-            CondImmune: finalCalcs.Immunities.join(', ') || 'None', Senses: finalCalcs.Senses.join(', ') || 'None', Languages: finalCalcs.Languages.join(', ') || 'None',
-            Features: finalCalcs.Features.map(f => ({ name: f.name, description: f.description, originalFeatureId: f.originalFeatureId })),
-            Combat: {
-                Check: `${finalCalcs.Check >= 0 ? '+' : ''}${finalCalcs.Check}`, SaveDC: finalCalcs.SaveDC.toString(),
-                AP: finalCalcs.AP.toString(), LAP: finalCalcs.LAP > 0 ? finalCalcs.LAP.toString() : '', Speed: finalCalcs.Speed.toString(),
-                Attacks: displayAttacks, OtherActions: otherDisplayCombatActions,
-                AttackEnhancements: finalCalcs.AttackEnhancements.map(enh => ({ name: `${enh.name} (${enh.cost || 'Special'})`, details: enh.description, originalFeatureId: enh.originalFeatureId })),
-            },
-            Reactions: finalCalcs.Reactions.map(re => ({ name: `${re.name} (${re.cost || 'Reaction'})`, details: re.description, originalFeatureId: re.originalFeatureId })),
-            ApexActions: finalCalcs.ApexActions.map(aa => ({ name: `${aa.name} (${aa.cost || 'Free'})`, details: aa.displayDescription || aa.description, originalFeatureId: aa.originalFeatureId })),
-        }
+      ...action,
+      damage: Math.ceil(calculatedDamage),
+      calculatedDamage: Math.ceil(calculatedDamage),
+      calculatedSaveDC,
+      displayCost,
+      description: action.description,
+      isAttack: isAttackAction(action),
     };
+  });
+
+const enhanceEnhancements = (rawStats, enhancements = []) =>
+  enhancements.map((enh) => ({
+    ...enh,
+    calculatedSaveDC: rawStats.SaveDC + (enh.saveDCMod || 0),
+    cost:
+      enh.costAP > 0
+        ? `+${enh.costAP} AP`
+        : enh.costMP > 0
+        ? `+${enh.costMP} MP`
+        : 'Special',
+  }));
+
+const enhanceReactions = (reactions = []) =>
+  reactions.map((reaction) => ({
+    ...reaction,
+    displayCost: reaction.costAP > 0 ? `${reaction.costAP} AP` : 'Reaction',
+  }));
+
+const enhanceApexActions = (rawStats, actions = []) =>
+  actions.map((action) => {
+    const calculatedDamage = (() => {
+      if (typeof action.baseDamageOverride === 'number') {
+        return action.baseDamageOverride + (action.damageMod || 0);
+      }
+      if (!isAttackAction(action)) {
+        return 0;
+      }
+      return rawStats.Damage + (action.damageMod || 0);
+    })();
+
+    const costParts = [];
+    if (action.costAP > 0) costParts.push(`${action.costAP} AP`);
+    if (action.costMP > 0) costParts.push(`${action.costMP} MP`);
+    const displayCost = costParts.join(' + ') || 'Free';
+
+    return {
+      ...action,
+      damage: Math.ceil(calculatedDamage),
+      calculatedSaveDC: rawStats.SaveDC + (action.saveDCMod || 0),
+      displayCost,
+      description: action.description,
+    };
+  });
+
+export const calculateCreatureStats = (
+  inputs,
+  selectedRawFeatures = [],
+  userOverrideDeltas = {},
+  defaultActionOverrides = {},
+) => {
+  const { stats: baseStats, context } = calculateBaseStats(inputs);
+
+  const statsWithFeatures = applyFeatureEffects(baseStats, selectedRawFeatures);
+  const snapshotBeforeOverrides = deepClone(statsWithFeatures);
+
+  const { stats: statsWithOverrides } = applyUserOverrides(
+    statsWithFeatures,
+    userOverrideDeltas,
+  );
+
+  finalizeDerivedValues(statsWithOverrides, context);
+
+  const defaultAttacks = buildDefaultAttacks(statsWithOverrides, context.roleMods);
+  const overriddenDefaultAttacks = applyDefaultActionOverrides(
+    defaultAttacks,
+    defaultActionOverrides,
+  );
+
+  const raw = {
+    ...statsWithOverrides,
+    DefaultAttacks: overriddenDefaultAttacks,
+  };
+
+  const derived = {
+    context,
+    snapshots: {
+      beforeOverrides: snapshotBeforeOverrides,
+    },
+    defaultAttacks: overriddenDefaultAttacks,
+    combatActions: enhanceActionData(raw, raw.CombatActions),
+    apexActions: enhanceApexActions(raw, raw.ApexActions),
+    reactions: enhanceReactions(raw.Reactions),
+    attackEnhancements: enhanceEnhancements(raw, raw.AttackEnhancements),
+  };
+
+  const display = formatForPresentation(raw, derived);
+
+  return {
+    raw,
+    derived,
+    display,
+  };
 };
 
 export const generateDefaultActionFeatures = (inputs) => {
-    const { FinalWithDeltas } = calculateCreatureStats(inputs, [], {}, {});
-    const parseRange = (rangeStr) => {
-        if (!rangeStr) return { rangeValue: 0, rangeUnit: '' };
-        const match = rangeStr.match(/(\d+)\s*(\w+)/);
-        if (match) {
-            return { rangeValue: parseInt(match[1], 10), rangeUnit: match[2].replace(/s$/, '') };
-        }
-        return { rangeValue: 0, rangeUnit: rangeStr };
+  const { stats: baseStats, context } = calculateBaseStats(inputs);
+  const finalized = finalizeDerivedValues(baseStats, context);
+  const defaultAttacks = buildDefaultAttacks(finalized, context.roleMods);
+
+  const describeAttack = (attack) => {
+    const parts = [];
+    if (attack.damage) {
+      const defense = attack.targetsDefense ? ` vs ${attack.targetsDefense}` : '';
+      parts.push(`${attack.damage} ${attack.damageType || 'damage'} damage${defense}.`);
+    }
+    if (attack.targetDescription) {
+      const range = attack.range ? ` within ${attack.range}` : '';
+      parts.push(`Target ${attack.targetDescription}${range}.`);
+    }
+    return parts.join(' ');
+  };
+
+  const parseRange = (rangeStr) => {
+    if (!rangeStr) return { rangeValue: 0, rangeUnit: '' };
+    const match = rangeStr.match(/(\d+)\s*(\w+)/);
+    if (match) {
+      return { rangeValue: parseInt(match[1], 10), rangeUnit: match[2].replace(/s$/, '') };
+    }
+    return { rangeValue: 0, rangeUnit: rangeStr };
+  };
+
+  return defaultAttacks.map((attack, idx) => {
+    const { rangeValue, rangeUnit } = parseRange(attack.range);
+    return {
+      id: `default-${idx}`,
+      name: attack.name,
+      category: 'action',
+      actionType: attack.type ? `${attack.type} Attack` : '',
+      costAP: attack.costAP,
+      costMP: 0,
+      costSP: 0,
+      damageMod: 0,
+      damageType: attack.damageType,
+      targetsDefense: attack.targetsDefense,
+      rangeValue,
+      rangeUnit,
+      targetDescription: attack.targetDescription,
+      descriptionCore: describeAttack(attack),
     };
-    return (FinalWithDeltas.DefaultAttacks || []).map((att, idx) => {
-        const { rangeValue, rangeUnit } = parseRange(att.range);
-        return {
-            id: `default-${idx}`,
-            name: att.name,
-            category: 'action',
-            actionType: att.type ? `${att.type} Attack` : '',
-            costAP: att.costAP,
-            costMP: 0,
-            costSP: 0,
-            damageMod: 0,
-            damageType: att.damageType,
-            targetsDefense: att.targetsDefense,
-            rangeValue,
-            rangeUnit,
-            targetDescription: att.targetDescription,
-            descriptionCore: att.details
-        };
-    });
+  });
 };

--- a/dc20-creature-creator/src/utils/featureEffects.js
+++ b/dc20-creature-creator/src/utils/featureEffects.js
@@ -1,0 +1,193 @@
+import { deepClone } from './baseStats';
+
+const mapActionFeature = (feature) => ({
+  id: feature.id,
+  name: feature.name,
+  category: feature.category,
+  actionType: feature.actionType,
+  costAP: feature.costAP || 0,
+  costMP: feature.costMP || 0,
+  costSP: feature.costSP || 0,
+  damageMod: feature.damageMod || 0,
+  damageType: feature.damageType,
+  targetsDefense: feature.targetsDefense,
+  rangeValue: feature.rangeValue || 0,
+  rangeUnit: feature.rangeUnit,
+  areaShape: feature.areaShape,
+  areaSize: feature.areaSize,
+  targetDescription: feature.targetDescription,
+  saveAttribute: feature.saveAttribute,
+  saveDCMod: feature.saveDCMod || 0,
+  conditionApplied: feature.conditionApplied,
+  conditionDuration: feature.conditionDuration,
+  healingAmount: feature.healingAmount,
+  description: feature.descriptionCore || feature.description,
+  baseDamageOverride: feature.baseDamageOverride,
+  descriptionCore: feature.descriptionCore,
+  originalFeatureId: feature.id || feature.originalFeatureId,
+});
+
+const mapEnhancementFeature = (feature) => ({
+  id: feature.id,
+  name: feature.name,
+  costAP: feature.costAP || 0,
+  costMP: feature.costMP || 0,
+  costSP: feature.costSP || 0,
+  description: feature.descriptionCore || feature.description,
+  saveAttribute: feature.saveAttribute,
+  saveDCMod: feature.saveDCMod || 0,
+  conditionApplied: feature.conditionApplied,
+  conditionDuration: feature.conditionDuration,
+  originalFeatureId: feature.id || feature.originalFeatureId,
+});
+
+export const applyFeatureEffects = (stats, selectedFeatures = []) => {
+  const working = deepClone(stats);
+
+  selectedFeatures.forEach((feature) => {
+    if (!feature || typeof feature !== 'object') return;
+
+    if (feature.category === 'feature' && Array.isArray(feature.effects)) {
+      feature.effects.forEach((effect) => {
+        const { stat, change, value } = effect || {};
+
+        if (Object.prototype.hasOwnProperty.call(working, stat)) {
+          if (change === 'add' && typeof value === 'number') {
+            working[stat] = (working[stat] || 0) + value;
+          } else if (change === 'set') {
+            working[stat] = value;
+          }
+          return;
+        }
+
+        if (Object.prototype.hasOwnProperty.call(working.Attributes, stat)) {
+          if (change === 'add' && typeof value === 'number') {
+            working.Attributes[stat] = (working.Attributes[stat] || 0) + value;
+          } else if (change === 'set') {
+            working.Attributes[stat] = value;
+          }
+          return;
+        }
+
+        if (stat === 'PDR' && change === 'set') {
+          working.PDR = value;
+          return;
+        }
+
+        if (stat === 'MaxMP' && change === 'add' && typeof value === 'number') {
+          working.MaxMP = (working.MaxMP || 0) + value;
+        }
+      });
+    }
+  });
+
+  working.Features = [];
+  working.CombatActions = [];
+  working.ApexActions = [];
+  working.Reactions = [];
+  working.AttackEnhancements = [];
+  working.Resistances = [];
+  working.Vulnerabilities = [];
+  working.Immunities = [];
+  working.Senses = [];
+  working.Languages = [];
+
+  selectedFeatures.forEach((feature) => {
+    if (!feature || typeof feature !== 'object') return;
+
+    const {
+      id,
+      name,
+      category,
+      value,
+      displayValue,
+      originalFeatureId,
+    } = feature;
+
+    switch (category) {
+      case 'feature':
+        working.Features.push({
+          name,
+          description: feature.descriptionCore || feature.description,
+          originalFeatureId: id || originalFeatureId,
+        });
+        break;
+      case 'action':
+        working.CombatActions.push(mapActionFeature(feature));
+        break;
+      case 'apex_action':
+        working.ApexActions.push(mapActionFeature(feature));
+        break;
+      case 'attack_enhancement':
+        working.AttackEnhancements.push(mapEnhancementFeature(feature));
+        break;
+      case 'reaction':
+        working.Reactions.push({
+          ...mapActionFeature(feature),
+        });
+        break;
+      case 'resistance':
+        working.Resistances.push(displayValue || value || name);
+        break;
+      case 'vulnerability':
+        working.Vulnerabilities.push(displayValue || value || name);
+        break;
+      case 'immunity':
+        working.Immunities.push(displayValue || value || name);
+        break;
+      case 'sense':
+        working.Senses.push(displayValue || value || name);
+        break;
+      case 'language':
+        working.Languages.push(displayValue || value || name);
+        break;
+      default:
+        break;
+    }
+  });
+
+  return working;
+};
+
+const buildAttackName = (base, flags) => {
+  if (flags.isCaster && flags.isMartial) return `${base} (Martial or Spell)`;
+  if (flags.isMartial) return `${base} Martial`;
+  if (flags.isCaster) return `${base} Spell`;
+  return base;
+};
+
+export const buildDefaultAttacks = (stats, roleMods = {}) => {
+  const attacks = [];
+  const baseDamage = stats.Damage;
+  const flags = { isCaster: stats.isCaster, isMartial: stats.isMartial };
+
+  const meleeAttack = {
+    name: buildAttackName('Melee Attack', flags),
+    costAP: 1,
+    type: buildAttackName('Melee', flags),
+    damage: baseDamage,
+    damageType: stats.isCaster && !stats.isMartial ? 'magical' : 'physical',
+    range: '1 space',
+    targetsDefense: 'PD',
+    targetDescription: '1 creature',
+  };
+  attacks.push(meleeAttack);
+
+  const rangeType = (stats.Range || '').toLowerCase();
+  if (rangeType && !['melee', 'touch', 'reach'].includes(rangeType)) {
+    const rangedDamageMod = roleMods?.DamageModRanged ?? 0;
+    const rangedAttack = {
+      name: buildAttackName('Ranged Attack', flags),
+      costAP: 2,
+      type: buildAttackName('Ranged', flags),
+      damage: baseDamage + rangedDamageMod + 1,
+      damageType: stats.isCaster && !stats.isMartial ? 'magical' : 'physical',
+      range: stats.Range,
+      targetsDefense: 'PD',
+      targetDescription: '1 creature',
+    };
+    attacks.push(rangedAttack);
+  }
+
+  return attacks;
+};

--- a/dc20-creature-creator/src/utils/overrideApplier.js
+++ b/dc20-creature-creator/src/utils/overrideApplier.js
@@ -1,0 +1,71 @@
+import { deepClone } from './baseStats';
+
+const isNumeric = (value) => typeof value === 'number' && Number.isFinite(value);
+
+export const applyUserOverrides = (stats, userOverrideDeltas = {}) => {
+  const working = deepClone(stats);
+  const attackOverrides = [];
+
+  Object.entries(userOverrideDeltas || {}).forEach(([fullOverrideKey, overrideStoredValue]) => {
+    const attackMatch = fullOverrideKey.match(/^Combat_Attacks_(\d+)_(.+)_(delta|set)$/);
+    if (attackMatch) {
+      const [, idxStr, field, type] = attackMatch;
+      attackOverrides.push({
+        index: parseInt(idxStr, 10),
+        field,
+        type,
+        value: overrideStoredValue,
+      });
+      return;
+    }
+
+    const parts = fullOverrideKey.split('_');
+    const suffix = parts.pop();
+    const fieldKey = parts.join('_');
+    const [mainKey, subKey] = fieldKey.split('_');
+
+    if (suffix === 'delta' && isNumeric(overrideStoredValue)) {
+      if (
+        subKey &&
+        working[mainKey] &&
+        typeof working[mainKey][subKey] === 'number'
+      ) {
+        working[mainKey][subKey] = (working[mainKey][subKey] || 0) + overrideStoredValue;
+      } else if (
+        Object.prototype.hasOwnProperty.call(working, mainKey) &&
+        typeof working[mainKey] === 'number'
+      ) {
+        working[mainKey] = (working[mainKey] || 0) + overrideStoredValue;
+      }
+      return;
+    }
+
+    if (suffix === 'set') {
+      if (
+        subKey &&
+        Object.prototype.hasOwnProperty.call(working, mainKey) &&
+        typeof working[mainKey] === 'object' &&
+        working[mainKey] !== null
+      ) {
+        working[mainKey][subKey] = overrideStoredValue;
+      } else if (Object.prototype.hasOwnProperty.call(working, fieldKey)) {
+        working[fieldKey] = overrideStoredValue;
+      }
+    }
+  });
+
+  return { stats: working, attackOverrides };
+};
+
+export const applyDefaultActionOverrides = (defaultAttacks, overrides = {}) => {
+  const working = defaultAttacks.map((attack) => ({ ...attack }));
+
+  Object.entries(overrides || {}).forEach(([idx, override]) => {
+    const index = parseInt(idx, 10);
+    if (!Number.isNaN(index) && working[index]) {
+      working[index] = { ...working[index], ...override };
+    }
+  });
+
+  return working;
+};

--- a/dc20-creature-creator/src/utils/presentationFormatter.js
+++ b/dc20-creature-creator/src/utils/presentationFormatter.js
@@ -1,0 +1,162 @@
+const capitalize = (value = '') =>
+  value.length > 0 ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+
+const formatSkillList = (skills = {}) => {
+  const entries = Object.entries(skills).map(([skill, bonus]) => {
+    const formattedSkill = capitalize(skill);
+    const sign = bonus >= 0 ? '+' : '';
+    return `${formattedSkill} ${sign}${bonus}`;
+  });
+
+  return entries.length > 0 ? entries.join(', ') : 'None';
+};
+
+const formatAttributeWithSave = (attributeValue, saveValue) => {
+  if (saveValue === null || typeof saveValue === 'undefined') {
+    return attributeValue.toString();
+  }
+  return `${attributeValue} (${saveValue})`;
+};
+
+const createAttackDescription = (attack, extra) => {
+  const parts = [];
+  if (attack.damage) {
+    const damageType = attack.damageType || 'damage';
+    const defense = attack.targetsDefense ? ` vs ${attack.targetsDefense}` : '';
+    parts.push(`${attack.damage} ${damageType} damage${defense}.`);
+  }
+
+  if (attack.targetDescription) {
+    const range = attack.range ? ` within ${attack.range}` : '';
+    parts.push(`Target ${attack.targetDescription}${range}.`);
+  }
+
+  if (extra?.saveAttribute) {
+    const saveDC = extra.calculatedSaveDC;
+    let saveText = `Target makes a ${extra.saveAttribute} save (DC ${saveDC})`;
+    if (extra.conditionApplied) {
+      saveText += ` or becomes ${extra.conditionApplied}`;
+      if (extra.conditionDuration) {
+        saveText += ` (${extra.conditionDuration.replace('your', 'its')})`;
+      }
+    } else {
+      saveText += ' for effect';
+    }
+    parts.push(`${saveText}.`);
+  } else if (extra?.conditionApplied) {
+    let conditionText = `Applies ${extra.conditionApplied}`;
+    if (extra.conditionDuration) {
+      conditionText += ` (${extra.conditionDuration.replace('your', 'its')})`;
+    }
+    parts.push(`${conditionText}.`);
+  }
+
+  if (extra?.healingAmount) {
+    parts.push(
+      extra.healingAmount === 'damage dealt'
+        ? 'You regain HP equal to damage dealt.'
+        : `Heals for ${extra.healingAmount} HP.`
+    );
+  }
+
+  if (extra?.description) {
+    parts.push(extra.description);
+  }
+
+  return parts.filter(Boolean).join(' ');
+};
+
+const formatAttackDisplay = (attack, extras = {}) => ({
+  name: attack.name,
+  costAP: attack.costAP || 0,
+  costMP: attack.costMP || 0,
+  details: createAttackDescription(attack, extras),
+  originalFeatureId: attack.originalFeatureId || null,
+});
+
+export const formatForPresentation = (raw, derived) => {
+  const display = {
+    HP: raw.HP,
+    PD: `${raw.PD} (${raw.PD + 5}/${raw.PD + 10})`,
+    AD: `${raw.AD} (${raw.AD + 5}/${raw.AD + 10})`,
+    MIG: formatAttributeWithSave(raw.Attributes.Mig, raw.Saves.Mig),
+    AGI: formatAttributeWithSave(raw.Attributes.Agi, raw.Saves.Agi),
+    CHA: formatAttributeWithSave(raw.Attributes.Cha, raw.Saves.Cha),
+    INT: formatAttributeWithSave(raw.Attributes.Int, raw.Saves.Int),
+    MaxMP: raw.MaxMP > 0 ? raw.MaxMP.toString() : '',
+    PDR: raw.PDR || '',
+    Skills: formatSkillList(raw.Skills),
+    Resistant: raw.Resistances.join(', ') || 'None',
+    Vulnerable: raw.Vulnerabilities.join(', ') || 'None',
+    CondImmune: raw.Immunities.join(', ') || 'None',
+    Senses: raw.Senses.join(', ') || 'None',
+    Languages: raw.Languages.join(', ') || 'None',
+    Features: raw.Features.map((feature) => ({
+      name: feature.name,
+      description: feature.description,
+      originalFeatureId: feature.originalFeatureId,
+    })),
+    Combat: {
+      Check: `${raw.Check >= 0 ? '+' : ''}${raw.Check}`,
+      SaveDC: raw.SaveDC.toString(),
+      AP: raw.AP.toString(),
+      LAP: raw.LAP > 0 ? raw.LAP.toString() : '',
+      Speed: raw.Speed.toString(),
+      Attacks: [],
+      OtherActions: [],
+      AttackEnhancements: [],
+    },
+    Reactions: [],
+    ApexActions: [],
+  };
+
+  const defaultAttacks = derived.defaultAttacks || [];
+  display.Combat.Attacks = defaultAttacks.map((attack) =>
+    formatAttackDisplay(
+      {
+        ...attack,
+        originalFeatureId: null,
+      },
+      attack,
+    )
+  );
+
+  const combatActions = derived.combatActions || [];
+  combatActions.forEach((action) => {
+    const formatted = formatAttackDisplay(action, action);
+    if (action.isAttack) {
+      display.Combat.Attacks.push(formatted);
+    } else {
+      display.Combat.OtherActions.push({
+        name: `${action.name} (${action.displayCost || 'Free'})`,
+        details: action.description,
+        originalFeatureId: action.originalFeatureId,
+      });
+    }
+  });
+
+  display.Combat.AttackEnhancements = (derived.attackEnhancements || []).map((enh) => ({
+    name: `${enh.name} (${enh.cost || 'Special'})`,
+    details: createAttackDescription({
+      damage: null,
+      targetsDefense: null,
+      targetDescription: null,
+      range: null,
+    }, enh),
+    originalFeatureId: enh.originalFeatureId,
+  }));
+
+  display.Reactions = (derived.reactions || []).map((reaction) => ({
+    name: `${reaction.name} (${reaction.displayCost || 'Reaction'})`,
+    details: reaction.description,
+    originalFeatureId: reaction.originalFeatureId,
+  }));
+
+  display.ApexActions = (derived.apexActions || []).map((action) => ({
+    name: `${action.name} (${action.displayCost || 'Free'})`,
+    details: createAttackDescription(action, action),
+    originalFeatureId: action.originalFeatureId,
+  }));
+
+  return display;
+};


### PR DESCRIPTION
## Summary
- split the monolithic stat calculator into base stats, feature application, override, and presentation helpers
- update calculateCreatureStats to return raw/derived/display structures and adjust page/components to consume them
- refresh default action generation and tests to cover the new structure

## Testing
- `npm run test -- src/utils/__tests__/calculateStats.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68dcefc8bf148331b5505a8bd2bcf2bf