### PR TITLE
Preserve generated default actions across resets

### DIFF
--- a/dc20-creature-creator/src/components/StatBlockPanel.jsx
+++ b/dc20-creature-creator/src/components/StatBlockPanel.jsx
@@ -10,18 +10,64 @@ import {
     GiMagicSwirl, GiCrossedSwords, GiUpgrade, GiReturnArrow, GiSandsOfTime
 } from 'react-icons/gi';
 
-const StatBlockPanel = forwardRef(({ fullStatBlock, onStatOverride, onRemoveFeature, onActionUpdate, onDefaultActionUpdate }, ref) => {
-    const raw = fullStatBlock?.raw;
-    const display = fullStatBlock?.display;
-    const derived = fullStatBlock?.derived;
-    const baseSnapshot = derived?.snapshots?.beforeOverrides;
+const StatBlockPanel = forwardRef(
+    (
+        {
+            fullStatBlock,
+            onStatOverride,
+            onRemoveFeature,
+            onActionUpdate,
+            onDefaultActionUpdate,
+            generatedDefaultActions = [],
+        },
+        ref,
+    ) => {
+        const raw = fullStatBlock?.raw;
+        const display = fullStatBlock?.display;
+        const derived = fullStatBlock?.derived;
+        const baseSnapshot = derived?.snapshots?.beforeOverrides;
 
-    if (!raw || !display || !baseSnapshot) {
-        return <div className="stat-block-panel" ref={ref}><p>Calculating stats...</p></div>;
-    }
+        if (!raw || !display || !baseSnapshot) {
+            return <div className="stat-block-panel" ref={ref}><p>Calculating stats...</p></div>;
+        }
 
-    const { Name, Level, Type, Role, Power } = raw; // Root level info
-    const finalRaw = raw; // For finding original features for removal
+        const { Name, Level, Type, Role, Power } = raw; // Root level info
+        const finalRaw = raw; // For finding original features for removal
+
+        const defaultAttacksRaw = Array.isArray(finalRaw?.DefaultAttacks) ? finalRaw.DefaultAttacks : [];
+        const defaultDisplayAttacks = Array.isArray(display?.Combat?.Attacks)
+            ? display.Combat.Attacks.filter((a) => !a.originalFeatureId)
+            : [];
+
+        const resolvedDefaultAttacks = defaultDisplayAttacks.length > 0
+            ? defaultDisplayAttacks.map((attack, index) => ({
+                key: `default-attack-${index}`,
+                action: {
+                    ...(defaultAttacksRaw[index] || {}),
+                    ...attack,
+                },
+            }))
+            : generatedDefaultActions.map((action, index) => {
+                const range = action.rangeValue
+                    ? `${action.rangeValue} ${action.rangeUnit || ''}`.trim()
+                    : action.range || '';
+
+                return {
+                    key: `generated-default-attack-${index}`,
+                    action: {
+                        name: action.name,
+                        costAP: action.costAP ?? 0,
+                        costMP: action.costMP ?? 0,
+                        damage: action.baseDamageOverride ?? 0,
+                        calculatedDamage: action.baseDamageOverride ?? 0,
+                        damageType: action.damageType ?? 'damage',
+                        targetsDefense: action.targetsDefense ?? 'PD',
+                        targetDescription: action.targetDescription ?? '',
+                        range,
+                        details: action.descriptionCore || action.description || '',
+                    },
+                };
+            });
 
     const getEditableNumericValue = (statString) => {
         if (typeof statString === 'string') {
@@ -233,13 +279,10 @@ const StatBlockPanel = forwardRef(({ fullStatBlock, onStatOverride, onRemoveFeat
 
 
                     {/* Default attacks with inline editable fields */}
-                    {display.Combat.Attacks && display.Combat.Attacks.filter(a => !a.originalFeatureId).map((attack, index) => (
-                        <div key={`default-attack-${index}`} className="sb-list-item attack-item">
+                    {resolvedDefaultAttacks.length > 0 && resolvedDefaultAttacks.map(({ key, action }, index) => (
+                        <div key={key} className="sb-list-item attack-item">
                             <ActionInlineDisplay
-                                action={{
-                                    ...finalRaw.DefaultAttacks[index],
-                                    ...attack,
-                                }}
+                                action={action}
                                 onSaveField={(field, val) => handleDefaultAttackFieldSave(index, field, val)}
                             />
                         </div>

--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
@@ -12,6 +12,7 @@ import {
   saveCreatureToSession,
   clearCreatureSession,
 } from '../domain/creatureBuilder';
+import { generateDefaultActionFeatures } from '../utils/calculateStats';
 import { db } from '../firebase';
 import { collection, query, getDocs, orderBy, addDoc, serverTimestamp } from 'firebase/firestore';
 import html2canvas from 'html2canvas';
@@ -56,6 +57,13 @@ const initializeCreatureState = () => normalizeCreatureState(loadCreatureFromSes
 const CreatureCreatorPage = ({ currentUser }) => {
   const [creatureState, dispatch] = useReducer(creatureStateReducer, undefined, initializeCreatureState);
   const { inputs, selectedFeatures, overrides, actionOverrides } = creatureState;
+
+  const generatedDefaultActions = useMemo(() => {
+    if (!inputs) {
+      return generateDefaultActionFeatures(getDefaultCreatureState().inputs);
+    }
+    return generateDefaultActionFeatures(inputs);
+  }, [inputs?.level, inputs?.power, inputs?.role, inputs?.type, inputs?.size]);
 
   const [allFeatures, setAllFeatures] = useState([]);
   const [isLoadingAllFeatures, setIsLoadingAllFeatures] = useState(true);
@@ -289,7 +297,8 @@ const CreatureCreatorPage = ({ currentUser }) => {
 
   const handleCreateNew = () => {
     console.log('Create New clicked');
-    dispatch({ type: 'RESET', payload: getDefaultCreatureState() });
+    const defaultState = getDefaultCreatureState();
+    dispatch({ type: 'RESET', payload: defaultState });
     clearCreatureSession();
     setIsCreatingFeature(false);
   };
@@ -380,6 +389,7 @@ const CreatureCreatorPage = ({ currentUser }) => {
           onRemoveFeature={handleRemoveSelectedFeature}
           onActionUpdate={handleActionUpdate}
           onDefaultActionUpdate={handleDefaultActionUpdate}
+          generatedDefaultActions={generatedDefaultActions}
         />
         <RightBar onCreateNew={handleCreateNew} onSave={handleSave} onExport={handleExport} />
       </div>

--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -180,6 +180,7 @@ export const generateDefaultActionFeatures = (inputs) => {
       rangeUnit,
       targetDescription: attack.targetDescription,
       descriptionCore: describeAttack(attack),
+      baseDamageOverride: attack.damage,
     };
   });
 };


### PR DESCRIPTION
## Summary
- derive the generated default actions in `CreatureCreatorPage` so resets reuse the baseline attacks
- feed those generated defaults into `StatBlockPanel` and fall back to them when the stat block lacks built-in attacks
- include base damage data in `generateDefaultActionFeatures` to support the fallback display

## Testing
- npm run test
- Manual validation (browser) – blocked: Playwright invocation failed inside the container environment

------
https://chatgpt.com/codex/tasks/task_e_68dcf88cee288331b27a421f467d4e81