### PR TITLE
Add balance guidance utilities and checklist UI

### DIFF
--- a/dc20-creature-creator/src/components/BalanceChecklist.css
+++ b/dc20-creature-creator/src/components/BalanceChecklist.css
@@ -1,0 +1,107 @@
+.balance-checklist {
+  background-color: var(--bg-light-panel, #fff);
+  color: var(--text-color-dark, #000);
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.balance-checklist h2 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.balance-summary {
+  border-left: 4px solid transparent;
+  padding: 12px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 6px;
+  margin-bottom: 16px;
+}
+
+.balance-summary ul {
+  margin: 8px 0 0 16px;
+  padding: 0;
+}
+
+.balance-summary.status-ok {
+  border-color: #2e7d32;
+}
+
+.balance-summary.status-warning {
+  border-color: #f9a825;
+}
+
+.balance-summary.status-critical {
+  border-color: #c62828;
+}
+
+.checklist-section + .checklist-section {
+  margin-top: 20px;
+}
+
+.checklist-section h3 {
+  margin-bottom: 10px;
+}
+
+.checklist-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.02);
+  margin-bottom: 8px;
+}
+
+.status-badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  font-weight: 700;
+  border-radius: 999px;
+  padding: 4px 10px;
+  color: #fff;
+  min-width: 70px;
+  text-align: center;
+}
+
+.status-badge.status-ok {
+  background-color: #2e7d32;
+}
+
+.status-badge.status-warning {
+  background-color: #f9a825;
+  color: #1f1f1f;
+}
+
+.status-badge.status-critical {
+  background-color: #c62828;
+}
+
+.checklist-row.status-ok {
+  border: 1px solid rgba(46, 125, 50, 0.15);
+}
+
+.checklist-row.status-warning {
+  border: 1px solid rgba(249, 168, 37, 0.25);
+}
+
+.checklist-row.status-critical {
+  border: 1px solid rgba(198, 40, 40, 0.3);
+}
+
+.checklist-row-details {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.checklist-row-details strong {
+  font-size: 0.95rem;
+}
+
+.checklist-row-details span {
+  font-size: 0.9rem;
+  color: #333;
+}

--- a/dc20-creature-creator/src/components/BalanceChecklist.jsx
+++ b/dc20-creature-creator/src/components/BalanceChecklist.jsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import './BalanceChecklist.css';
+
+const toneToLabel = (tone) => {
+  switch (tone) {
+    case 'critical':
+      return 'Critical';
+    case 'warning':
+      return 'Warning';
+    default:
+      return 'OK';
+  }
+};
+
+const directionDescriptor = (direction) => {
+  if (direction === 'high') return 'above';
+  if (direction === 'low') return 'below';
+  return 'on target';
+};
+
+const formatDelta = (delta) => {
+  if (typeof delta !== 'number' || Number.isNaN(delta)) return '';
+  if (delta === 0) return '±0';
+  return delta > 0 ? `+${Math.round(delta * 100) / 100}` : `${Math.round(delta * 100) / 100}`;
+};
+
+const formatValue = (value) => {
+  if (value === null || typeof value === 'undefined') {
+    return '—';
+  }
+  return value;
+};
+
+const buildMetricDeltaText = (metric) => {
+  if (metric.actual === null || metric.baseline === null) {
+    return '';
+  }
+  const parts = [];
+  if (metric.delta !== null) {
+    parts.push(formatDelta(metric.delta));
+  }
+  if (metric.percentDelta !== null && metric.percentDelta !== 0) {
+    const rounded = Math.round(metric.percentDelta);
+    parts.push(`${rounded > 0 ? '+' : ''}${rounded}%`);
+  }
+  if (parts.length === 0) {
+    return '';
+  }
+  return ` (${parts.join(', ')})`;
+};
+
+const BalanceChecklist = ({ report }) => {
+  if (!report) {
+    return (
+      <section className="balance-checklist">
+        <h2>Balance Review</h2>
+        <p className="balance-summary status-warning">Balance data is not available yet.</p>
+      </section>
+    );
+  }
+
+  const { metrics, featureCost, attributeSummary, attackCoverage, overall } = report;
+
+  return (
+    <section className="balance-checklist">
+      <h2>Balance Review</h2>
+      <div className={`balance-summary status-${overall.tone}`}>
+        <strong>{overall.message}</strong>
+        {overall.details?.length > 0 && (
+          <ul>
+            {overall.details.map((detail, index) => (
+              <li key={`summary-detail-${index}`}>{detail}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="checklist-section">
+        <h3>Feature Budget</h3>
+        <div className={`checklist-row status-${featureCost.tone}`}>
+          <span className={`status-badge status-${featureCost.tone}`}>{toneToLabel(featureCost.tone)}</span>
+          <div className="checklist-row-details">
+            <strong>Feature Cost</strong>
+            <span>
+              Expected {featureCost.budget.min}–{featureCost.budget.max}, current {featureCost.total}.
+              {featureCost.direction !== 'ok' && ` This is ${directionDescriptor(featureCost.direction)} the recommended range.`}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="checklist-section">
+        <h3>Core Stats</h3>
+        {metrics.map((metric) => (
+          <div key={metric.id} className={`checklist-row status-${metric.tone}`}>
+            <span className={`status-badge status-${metric.tone}`}>{toneToLabel(metric.tone)}</span>
+            <div className="checklist-row-details">
+              <strong>{metric.label}</strong>
+              <span>
+                {formatValue(metric.actual)} vs baseline {formatValue(metric.baseline)}
+                {buildMetricDeltaText(metric)}
+                {metric.direction !== 'ok' && metric.tone !== 'ok' && ` — ${directionDescriptor(metric.direction)} of expectations.`}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="checklist-section">
+        <h3>Attributes & Saves</h3>
+        {[attributeSummary.total, attributeSummary.max].map((summary) => (
+          <div key={summary.label} className={`checklist-row status-${summary.tone}`}>
+            <span className={`status-badge status-${summary.tone}`}>{toneToLabel(summary.tone)}</span>
+            <div className="checklist-row-details">
+              <strong>{summary.label}</strong>
+              <span>
+                {formatValue(summary.actual)} vs expected {formatValue(summary.expected)}
+                {` (${formatDelta(summary.delta)})`}
+                {summary.direction !== 'ok' && summary.tone !== 'ok' && ` — ${directionDescriptor(summary.direction)} the level guideline.`}
+              </span>
+            </div>
+          </div>
+        ))}
+        {attributeSummary.saveWarnings.length > 0 ? (
+          attributeSummary.saveWarnings.map((warning) => (
+            <div key={warning.attribute} className={`checklist-row status-${warning.tone}`}>
+              <span className={`status-badge status-${warning.tone}`}>{toneToLabel(warning.tone)}</span>
+              <div className="checklist-row-details">
+                <strong>{warning.attribute}</strong>
+                <span>
+                  {formatValue(warning.actual)} vs baseline {formatValue(warning.baseline)}
+                  {` (${formatDelta(warning.delta)})`}
+                  {warning.direction !== 'ok' && ` — ${directionDescriptor(warning.direction)} proficiency.`}
+                </span>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="checklist-row status-ok">
+            <span className="status-badge status-ok">OK</span>
+            <div className="checklist-row-details">
+              <strong>Saves</strong>
+              <span>All tracked saves are within the expected range.</span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="checklist-section">
+        <h3>Attack Coverage</h3>
+        <div className={`checklist-row status-${attackCoverage.tone}`}>
+          <span className={`status-badge status-${attackCoverage.tone}`}>{toneToLabel(attackCoverage.tone)}</span>
+          <div className="checklist-row-details">
+            <strong>PD & AD Coverage</strong>
+            <span>{attackCoverage.message}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BalanceChecklist;

--- a/dc20-creature-creator/src/components/FeatureCreationForm.css
+++ b/dc20-creature-creator/src/components/FeatureCreationForm.css
@@ -26,6 +26,13 @@
     font-size: 0.9em;
 }
 
+.feature-creation-form .form-helper-text {
+    display: block;
+    margin-top: 4px;
+    color: #555;
+    font-size: 0.8em;
+}
+
 .feature-creation-form input[type="text"],
 .feature-creation-form input[type="number"],
 .feature-creation-form textarea,

--- a/dc20-creature-creator/src/components/FeatureCreationForm.jsx
+++ b/dc20-creature-creator/src/components/FeatureCreationForm.jsx
@@ -55,6 +55,7 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
     const [costAP, setCostAP] = useState(''); // Use string for empty input, parse to number later
     const [costMP, setCostMP] = useState('');
     const [costSP, setCostSP] = useState('');
+    const [balanceCost, setBalanceCost] = useState('1');
     const [actionType, setActionType] = useState('');
     const [damageMod, setDamageMod] = useState('');
     const [damageType, setDamageType] = useState('');
@@ -81,6 +82,7 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
     const resetForm = () => {
         setName(''); setCategory('feature'); setDescription(''); setTags('');
         setCostAP(''); setCostMP(''); setCostSP('');
+        setBalanceCost('1');
         setActionType(''); setDamageMod(''); setDamageType(''); setRange('');
         setTargets(''); setDuration(''); setSaveAttribute(''); setSaveEffect('');
         setConditionApplied(''); setHealingAmount('');
@@ -91,6 +93,8 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
         const numAP = parseInt(costAP, 10) || 0;
         const numMP = parseInt(costMP, 10) || 0;
         const numSP = parseInt(costSP, 10) || 0;
+        const parsedBalanceCost = parseFloat(balanceCost);
+        const numericBalanceCost = Number.isNaN(parsedBalanceCost) ? 1 : Math.max(0, parsedBalanceCost);
 
         if (numAP > 0) costStringParts.push(`${numAP} AP`);
         if (numMP > 0) costStringParts.push(`${numMP} MP`);
@@ -121,6 +125,7 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
             saveEffect: saveAttribute ? saveEffect.trim() : null, // Only relevant if there's a save
             conditionApplied: conditionApplied.trim() || null,
             healingAmount: (category === 'action' && actionType === 'Healing') ? healingAmount.trim() : null,
+            balanceCost: numericBalanceCost,
         };
     };
 
@@ -180,6 +185,19 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
             <div className="form-group">
                 <label htmlFor="customFeatureDesc">Description:</label>
                 <textarea id="customFeatureDesc" value={description} onChange={e => setDescription(e.target.value)} rows="3" placeholder="What this trait does..."></textarea>
+            </div>
+
+            <div className="form-group">
+                <label htmlFor="customFeatureBalanceCost">Balance Cost:</label>
+                <input
+                    type="number"
+                    id="customFeatureBalanceCost"
+                    min="0"
+                    step="0.5"
+                    value={balanceCost}
+                    onChange={(e) => setBalanceCost(e.target.value)}
+                />
+                <small className="form-helper-text">Set to 1 for a standard-strength feature. Increase the value for stronger effects.</small>
             </div>
 
             {/* --- Cost Inputs --- */}

--- a/dc20-creature-creator/src/components/InputPanel.css
+++ b/dc20-creature-creator/src/components/InputPanel.css
@@ -42,6 +42,12 @@
     color: #777;
 }
 
+.feature-balance-cost {
+    font-size: 0.85em;
+    margin-left: 8px;
+    color: #555;
+}
+
 .feature-description {
     /* Style if you keep the <p> description visible */
     font-size: 0.9em;

--- a/dc20-creature-creator/src/components/InputPanel.jsx
+++ b/dc20-creature-creator/src/components/InputPanel.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import './InputPanel.css';
 import FeatureCreationForm from './FeatureCreationForm';
+import { normalizeFeatureBalanceCost } from '../utils/featureCost';
 
 const InputPanel = ({
   inputs,
@@ -71,6 +72,8 @@ const InputPanel = ({
             return null;
           }
           const isChecked = selectedFeatures.some((sf) => sf.id === feature.id);
+          const normalizedBalance = normalizeFeatureBalanceCost(feature);
+          const displayBalance = Number.isInteger(normalizedBalance) ? normalizedBalance : normalizedBalance.toFixed(1);
           return (
             <li key={`${listContextKey}-${feature.id}`}>
               <label title={feature.description}>
@@ -78,6 +81,7 @@ const InputPanel = ({
                 <strong className="feature-name">{feature.name}</strong>
                 <span className="feature-category">({feature.category})</span>
                 {feature.cost && <span className="feature-cost"> - Cost: {feature.cost}</span>}
+                <span className="feature-balance-cost">• Feature Cost: {displayBalance}</span>
               </label>
             </li>
           );

--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.css
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.css
@@ -31,17 +31,29 @@ body {
 }
 
 .stat-block-panel {
-  flex: 2;
-  /* Takes 2 parts of the available space */
   background-color: var(--bg-light-panel, #fff);
   color: var(--text-color-dark, #000);
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  min-width: 0;
+  width: 100%;
+}
+
+.middle-column {
+  flex: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
   min-width: 400px;
-  /* Give it a decent minimum width */
-  overflow-y: auto;
-  /* Allow scrolling */
+}
+
+.middle-column .stat-block-panel {
+  flex: 0 0 auto;
+}
+
+.middle-column .balance-checklist {
+  flex: 0 0 auto;
 }
 
 /* RightBar is now a flex item, its own CSS (.right-bar) will define its specific flex properties if needed */

--- a/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
+++ b/dc20-creature-creator/src/pages/CreatureCreatorPage.jsx
@@ -4,6 +4,7 @@ import './CreatureCreatorPage.css';
 import RightBar from '../components/RightBar';
 import InputPanel from '../components/InputPanel';
 import StatBlockPanel from '../components/StatBlockPanel';
+import BalanceChecklist from '../components/BalanceChecklist';
 import {
   buildCreature,
   getDefaultCreatureState,
@@ -13,6 +14,7 @@ import {
   clearCreatureSession,
 } from '../domain/creatureBuilder';
 import { generateDefaultActionFeatures } from '../utils/calculateStats';
+import { evaluateBalance } from '../utils/balanceGuidelines';
 import { db } from '../firebase';
 import { collection, query, getDocs, orderBy, addDoc, serverTimestamp } from 'firebase/firestore';
 import html2canvas from 'html2canvas';
@@ -79,6 +81,19 @@ const CreatureCreatorPage = ({ currentUser }) => {
     [inputs, selectedFeatures, overrides, actionOverrides]
   );
   const statBlock = creatureBuild.creature;
+
+  const balanceReport = useMemo(() => {
+    if (!creatureBuild?.creature) {
+      return null;
+    }
+    return evaluateBalance({
+      inputs,
+      selectedFeatures,
+      overrides,
+      actionOverrides,
+      creature: creatureBuild.creature,
+    });
+  }, [inputs, selectedFeatures, overrides, actionOverrides, creatureBuild]);
 
   useEffect(() => {
     saveCreatureToSession(creatureState);
@@ -382,15 +397,18 @@ const CreatureCreatorPage = ({ currentUser }) => {
           onAddCustomFeatureToSelection={handleAddCustomFeatureToSelection}
           onSaveCustomFeatureToDBAndAddToSelection={handleSaveCustomFeatureToDBAndAddToSelection}
         />
-        <StatBlockPanel
-          ref={statBlockRef}
-          fullStatBlock={statBlock}
-          onStatOverride={handleStatOverride}
-          onRemoveFeature={handleRemoveSelectedFeature}
-          onActionUpdate={handleActionUpdate}
-          onDefaultActionUpdate={handleDefaultActionUpdate}
-          generatedDefaultActions={generatedDefaultActions}
-        />
+        <div className="middle-column">
+          <StatBlockPanel
+            ref={statBlockRef}
+            fullStatBlock={statBlock}
+            onStatOverride={handleStatOverride}
+            onRemoveFeature={handleRemoveSelectedFeature}
+            onActionUpdate={handleActionUpdate}
+            onDefaultActionUpdate={handleDefaultActionUpdate}
+            generatedDefaultActions={generatedDefaultActions}
+          />
+          <BalanceChecklist report={balanceReport} />
+        </div>
         <RightBar onCreateNew={handleCreateNew} onSave={handleSave} onExport={handleExport} />
       </div>
     </>

--- a/dc20-creature-creator/src/uploadFeatures.cjs
+++ b/dc20-creature-creator/src/uploadFeatures.cjs
@@ -18,7 +18,7 @@ try {
 
 const db = admin.firestore();
 
-const allCreatureFeatures = [
+const rawCreatureFeatures = [
     // --- PASSIVE FEATURES (for ABILITIES section) ---
     {
         id: "undead_deaths_door",
@@ -435,6 +435,17 @@ const allCreatureFeatures = [
         conditionDuration: "1 round",
     },
 ];
+
+const allCreatureFeatures = rawCreatureFeatures.map((feature) => {
+    const numericCost =
+        typeof feature.balanceCost === 'number' && Number.isFinite(feature.balanceCost)
+            ? Math.max(0, feature.balanceCost)
+            : 1;
+    return {
+        ...feature,
+        balanceCost: numericCost,
+    };
+});
 
 async function uploadFeatures() {
     const featuresCollection = db.collection('features');

--- a/dc20-creature-creator/src/utils/__tests__/balanceGuidelines.test.js
+++ b/dc20-creature-creator/src/utils/__tests__/balanceGuidelines.test.js
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { calculateBaseStats, finalizeDerivedValues, deepClone } from '../baseStats';
+import { evaluateBalance, getFeatureCostBudget } from '../balanceGuidelines';
+
+const buildBaselineCreature = (inputs) => {
+  const { stats, context } = calculateBaseStats(inputs);
+  finalizeDerivedValues(stats, context);
+  const base = deepClone(stats);
+  base.DefaultAttacks = [
+    { name: 'Melee Attack', targetsDefense: 'PD' },
+    { name: 'Ranged Attack', targetsDefense: 'AD' },
+  ];
+  base.CombatActions = [];
+  base.ApexActions = [];
+  base.Reactions = [];
+  return base;
+};
+
+describe('getFeatureCostBudget', () => {
+  it('scales the expected range by power tier', () => {
+    const normal = getFeatureCostBudget(5, 'Normal');
+    const legendary = getFeatureCostBudget(5, 'Legendary');
+
+    expect(normal.expected).toBe(7);
+    expect(normal.min).toBe(6);
+    expect(normal.max).toBe(8);
+
+    expect(legendary.expected).toBe(14);
+    expect(legendary.min).toBe(12);
+    expect(legendary.max).toBe(16);
+  });
+});
+
+describe('evaluateBalance', () => {
+  const baseInputs = {
+    level: 3,
+    power: 'Normal',
+    role: 'none',
+    type: 'undead',
+    size: 'medium',
+  };
+
+  it('reports on-target when stats and feature cost are within expectations', () => {
+    const baseline = buildBaselineCreature(baseInputs);
+    const selectedFeatures = Array.from({ length: 5 }, (_, index) => ({
+      id: `feat-${index}`,
+      balanceCost: 1,
+      category: 'feature',
+    }));
+
+    const report = evaluateBalance({
+      inputs: baseInputs,
+      selectedFeatures,
+      creature: { raw: baseline },
+    });
+
+    expect(report.overall.status).toBe('on-target');
+    expect(report.featureCost.status).toBe('ok');
+    expect(report.metrics.every((metric) => metric.tone === 'ok')).toBe(true);
+    expect(report.attackCoverage.tone).toBe('ok');
+  });
+
+  it('flags multiple high deviations and missing AD coverage', () => {
+    const baseline = buildBaselineCreature(baseInputs);
+    const boosted = {
+      ...baseline,
+      HP: baseline.HP + 20,
+      PD: baseline.PD + 4,
+      Attributes: {
+        ...baseline.Attributes,
+        Mig: (baseline.Attributes.Mig || 0) + 3,
+      },
+      Saves: {
+        ...baseline.Saves,
+        Mig: (baseline.Saves.Mig || 0) + 4,
+      },
+      DefaultAttacks: [{ name: 'Melee Attack', targetsDefense: 'PD' }],
+    };
+
+    const selectedFeatures = [
+      { id: 'feat-over', balanceCost: 5, category: 'feature' },
+      { id: 'feat-over-2', balanceCost: 5, category: 'feature' },
+    ];
+
+    const report = evaluateBalance({
+      inputs: baseInputs,
+      selectedFeatures,
+      creature: { raw: boosted },
+    });
+
+    expect(report.featureCost.status).toBe('over');
+    expect(report.attributeSummary.total.direction).toBe('high');
+    expect(report.attackCoverage.tone).toBe('warning');
+    expect(report.overall.status).toBe('likely-too-strong');
+  });
+});

--- a/dc20-creature-creator/src/utils/__tests__/featureCost.test.js
+++ b/dc20-creature-creator/src/utils/__tests__/featureCost.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeFeatureBalanceCost, sumFeatureBalanceCost } from '../featureCost';
+
+describe('feature cost helpers', () => {
+  it('normalizes numeric values directly', () => {
+    expect(normalizeFeatureBalanceCost({ balanceCost: 2 })).toBe(2);
+  });
+
+  it('defaults to 1 when value missing', () => {
+    expect(normalizeFeatureBalanceCost({})).toBe(1);
+  });
+
+  it('parses string values and clamps negatives to zero', () => {
+    expect(normalizeFeatureBalanceCost({ balanceCost: '3.5' })).toBe(3.5);
+    expect(normalizeFeatureBalanceCost({ balanceCost: '-2' })).toBe(0);
+  });
+
+  it('sums an array of features with defaults', () => {
+    const features = [
+      { balanceCost: 2 },
+      { balanceCost: '1' },
+      {},
+    ];
+    expect(sumFeatureBalanceCost(features)).toBe(2 + 1 + 1);
+  });
+
+  it('returns 0 when given a non-array', () => {
+    expect(sumFeatureBalanceCost(null)).toBe(0);
+    expect(sumFeatureBalanceCost(undefined)).toBe(0);
+  });
+});

--- a/dc20-creature-creator/src/utils/balanceGuidelines.js
+++ b/dc20-creature-creator/src/utils/balanceGuidelines.js
@@ -1,0 +1,396 @@
+import { calculateBaseStats, finalizeDerivedValues, deepClone } from './baseStats';
+import { attributeScoresByLevel } from '../data/gameRules';
+import { sumFeatureBalanceCost } from './featureCost';
+
+const powerCostMultipliers = {
+  minion: 0.5,
+  weak: 0.75,
+  normal: 1,
+  apex: 1.5,
+  legendary: 2,
+};
+
+const METRIC_DEFINITIONS = [
+  {
+    id: 'hp',
+    key: 'HP',
+    label: 'Hit Points',
+    soft: { pct: 0.2, abs: 4 },
+    hard: { pct: 0.3, abs: 6 },
+  },
+  {
+    id: 'pd',
+    key: 'PD',
+    label: 'Precision Defense',
+    soft: { abs: 1 },
+    hard: { abs: 3 },
+  },
+  {
+    id: 'ad',
+    key: 'AD',
+    label: 'Area Defense',
+    soft: { abs: 1 },
+    hard: { abs: 3 },
+  },
+  {
+    id: 'check',
+    key: 'Check',
+    label: 'Check Bonus',
+    soft: { abs: 1 },
+    hard: { abs: 2 },
+  },
+  {
+    id: 'damage',
+    key: 'Damage',
+    label: 'Base Damage',
+    soft: { pct: 0.15, abs: 1 },
+    hard: { pct: 0.25, abs: 2 },
+  },
+  {
+    id: 'savedc',
+    key: 'SaveDC',
+    label: 'Save DC',
+    soft: { abs: 1 },
+    hard: { abs: 2 },
+  },
+];
+
+const halfStep = (value) => Math.round(value * 2) / 2;
+
+export const getFeatureCostBudget = (level = 0, power = 'normal') => {
+  const normalizedLevel = Number.isFinite(level) ? Math.max(0, level) : 0;
+  const baseBudget = normalizedLevel + 2; // Normal power expectation
+  const lowerBand = Math.max(0, baseBudget - 1);
+  const upperBand = baseBudget + 1;
+
+  const multiplier = powerCostMultipliers[power?.toLowerCase?.() || 'normal'] ?? 1;
+
+  const expected = halfStep(baseBudget * multiplier);
+  const min = halfStep(lowerBand * multiplier);
+  const max = halfStep(Math.max(lowerBand, upperBand) * multiplier);
+
+  return {
+    expected,
+    min,
+    max,
+  };
+};
+
+const evaluateStatMetric = (definition, actualValue, baselineValue) => {
+  const { id, label } = definition;
+  const safeActual = typeof actualValue === 'number' ? actualValue : null;
+  const safeBaseline = typeof baselineValue === 'number' ? baselineValue : null;
+
+  if (safeActual === null || safeBaseline === null) {
+    return {
+      id,
+      label,
+      actual: safeActual,
+      baseline: safeBaseline,
+      delta: null,
+      percentDelta: null,
+      direction: 'unknown',
+      tone: 'ok',
+      exceedsHard: false,
+    };
+  }
+
+  const delta = safeActual - safeBaseline;
+  const absDelta = Math.abs(delta);
+
+  const softLimitPct = (definition.soft?.pct || 0) * safeBaseline;
+  const softLimitAbs = definition.soft?.abs ?? 0;
+  const hardLimitPct = (definition.hard?.pct || 0) * safeBaseline;
+  const hardLimitAbs = definition.hard?.abs ?? 0;
+
+  const softLimit = Math.max(softLimitPct, softLimitAbs);
+  const hardLimit = Math.max(hardLimitPct, hardLimitAbs);
+
+  let tone = 'ok';
+  let direction = 'ok';
+  let exceedsHard = false;
+
+  if (hardLimit > 0 && absDelta >= hardLimit) {
+    tone = 'critical';
+    direction = delta > 0 ? 'high' : 'low';
+    exceedsHard = true;
+  } else if (softLimit > 0 && absDelta >= softLimit) {
+    tone = 'warning';
+    direction = delta > 0 ? 'high' : 'low';
+  }
+
+  return {
+    id,
+    label,
+    actual: safeActual,
+    baseline: safeBaseline,
+    delta,
+    percentDelta: safeBaseline !== 0 ? (delta / safeBaseline) * 100 : null,
+    direction,
+    tone,
+    exceedsHard,
+  };
+};
+
+const describeSignals = (signals) =>
+  signals
+    .map((signal) => signal.label || signal.attribute || signal.name)
+    .filter(Boolean)
+    .join(', ');
+
+const evaluateAttributes = (actualStats, baselineStats, level) => {
+  const attributeEntry = attributeScoresByLevel
+    .slice()
+    .reverse()
+    .find((entry) => typeof level === 'number' && level >= entry.level) || attributeScoresByLevel[0];
+
+  const expectedScores = attributeEntry?.scores || [0, 0, 0, 0];
+  const expectedTotal = expectedScores.slice(0, 4).reduce((sum, value) => sum + value, 0);
+  const expectedMax = Math.max(...expectedScores.slice(0, 4));
+
+  const actualAttributes = actualStats?.Attributes || {};
+  const attributeKeys = ['Mig', 'Agi', 'Int', 'Cha'];
+  const actualValues = attributeKeys.map((key) => actualAttributes[key] ?? 0);
+  const actualTotal = actualValues.reduce((sum, value) => sum + value, 0);
+  const actualMax = Math.max(...actualValues);
+
+  const totalDelta = actualTotal - expectedTotal;
+  const maxDelta = actualMax - expectedMax;
+
+  const totalTone = Math.abs(totalDelta) >= 2 ? 'critical' : Math.abs(totalDelta) >= 1 ? 'warning' : 'ok';
+  const maxTone = Math.abs(maxDelta) >= 2 ? 'critical' : Math.abs(maxDelta) >= 1 ? 'warning' : 'ok';
+
+  const totalDirection = totalDelta > 0 ? 'high' : totalDelta < 0 ? 'low' : 'ok';
+  const maxDirection = maxDelta > 0 ? 'high' : maxDelta < 0 ? 'low' : 'ok';
+
+  const saveWarnings = [];
+  const actualSaves = actualStats?.Saves || {};
+  const baselineSaves = baselineStats?.Saves || {};
+
+  attributeKeys.forEach((attr) => {
+    const actual = actualSaves[attr];
+    const baseline = baselineSaves[attr];
+    if (typeof actual !== 'number' || typeof baseline !== 'number') {
+      return;
+    }
+    const delta = actual - baseline;
+    if (Math.abs(delta) > 1) {
+      saveWarnings.push({
+        attribute: `${attr} Save`,
+        delta,
+        baseline,
+        actual,
+        tone: Math.abs(delta) >= 3 ? 'critical' : 'warning',
+        direction: delta > 0 ? 'high' : 'low',
+        label: `${attr} Save`,
+      });
+    }
+  });
+
+  return {
+    total: {
+      actual: actualTotal,
+      expected: expectedTotal,
+      delta: totalDelta,
+      tone: totalTone,
+      direction: totalDirection,
+      label: 'Attribute Total',
+    },
+    max: {
+      actual: actualMax,
+      expected: expectedMax,
+      delta: maxDelta,
+      tone: maxTone,
+      direction: maxDirection,
+      label: 'Highest Attribute',
+    },
+    saveWarnings,
+  };
+};
+
+const evaluateFeatureCost = (totalCost, budget) => {
+  const delta = totalCost - budget.expected;
+  const direction = delta > 0 ? 'high' : delta < 0 ? 'low' : 'ok';
+
+  let tone = 'ok';
+  let status = 'ok';
+
+  if (totalCost > budget.max) {
+    status = 'over';
+    const excess = totalCost - budget.max;
+    const tolerance = Math.max(1, budget.max - budget.min);
+    tone = excess >= tolerance ? 'critical' : 'warning';
+  } else if (totalCost < budget.min) {
+    status = 'under';
+    const shortage = budget.min - totalCost;
+    const tolerance = Math.max(1, budget.max - budget.min);
+    tone = shortage >= tolerance ? 'critical' : 'warning';
+  }
+
+  return {
+    label: 'Feature Cost',
+    total: totalCost,
+    budget,
+    delta,
+    direction,
+    tone,
+    status,
+  };
+};
+
+const evaluateAttackCoverage = (creatureStats, selectedFeatures = []) => {
+  const defTargets = new Set();
+
+  const registerDefense = (value) => {
+    if (typeof value !== 'string') return;
+    const clean = value.trim().toUpperCase();
+    if (clean) {
+      defTargets.add(clean);
+    }
+  };
+
+  const iterateActions = (actions) => {
+    if (!Array.isArray(actions)) return;
+    actions.forEach((action) => {
+      if (!action || typeof action !== 'object') return;
+      registerDefense(action.targetsDefense || action.targets_defense || action.defenseTarget);
+    });
+  };
+
+  iterateActions(creatureStats?.DefaultAttacks);
+  iterateActions(creatureStats?.CombatActions);
+  iterateActions(creatureStats?.ApexActions);
+  iterateActions(creatureStats?.Reactions);
+
+  selectedFeatures
+    .filter((feature) => feature && feature.category === 'action')
+    .forEach((feature) => registerDefense(feature.targetsDefense));
+
+  const hasPD = defTargets.has('PD');
+  const hasAD = defTargets.has('AD');
+
+  let tone = 'ok';
+  const missing = [];
+  if (!hasPD) missing.push('an attack targeting PD');
+  if (!hasAD) missing.push('an attack targeting AD');
+  if (missing.length > 0) {
+    tone = 'warning';
+  }
+
+  return {
+    hasPD,
+    hasAD,
+    tone,
+    missing,
+    message:
+      missing.length === 0
+        ? 'This creature pressures both PD and AD.'
+        : `Add ${missing.join(' and ')} to keep defenses balanced.`,
+  };
+};
+
+export const evaluateBalance = ({ inputs, selectedFeatures = [], creature }) => {
+  if (!inputs) {
+    return null;
+  }
+
+  const { stats: baselineStatsRaw, context } = calculateBaseStats(inputs);
+  const baselineStats = finalizeDerivedValues(deepClone(baselineStatsRaw), context);
+
+  const actualContainer = creature || {};
+  const actualStats = actualContainer.raw || actualContainer;
+
+  const metrics = METRIC_DEFINITIONS.map((definition) =>
+    evaluateStatMetric(definition, actualStats?.[definition.key], baselineStats?.[definition.key])
+  );
+
+  const featureCostTotal = sumFeatureBalanceCost(selectedFeatures);
+  const featureBudget = getFeatureCostBudget(inputs.level, inputs.power);
+  const featureCost = evaluateFeatureCost(featureCostTotal, featureBudget);
+
+  const attributeSummary = evaluateAttributes(actualStats, baselineStats, inputs.level);
+
+  const attackCoverage = evaluateAttackCoverage(actualStats, selectedFeatures);
+
+  const highSignals = [];
+  const lowSignals = [];
+
+  metrics.forEach((metric) => {
+    if (metric.direction === 'high' && metric.tone !== 'ok') {
+      highSignals.push(metric);
+    } else if (metric.direction === 'low' && metric.tone !== 'ok') {
+      lowSignals.push(metric);
+    }
+  });
+
+  if (featureCost.direction === 'high' && featureCost.tone !== 'ok') {
+    highSignals.push(featureCost);
+  } else if (featureCost.direction === 'low' && featureCost.tone !== 'ok') {
+    lowSignals.push(featureCost);
+  }
+
+  [attributeSummary.total, attributeSummary.max].forEach((summary) => {
+    if (summary.tone !== 'ok') {
+      if (summary.direction === 'high') {
+        highSignals.push(summary);
+      } else if (summary.direction === 'low') {
+        lowSignals.push(summary);
+      }
+    }
+  });
+
+  attributeSummary.saveWarnings.forEach((warning) => {
+    if (warning.direction === 'high') {
+      highSignals.push(warning);
+    } else if (warning.direction === 'low') {
+      lowSignals.push(warning);
+    }
+  });
+
+  const highCritical = highSignals.some((signal) => signal.tone === 'critical' || signal.exceedsHard);
+  const lowCritical = lowSignals.some((signal) => signal.tone === 'critical' || signal.exceedsHard);
+
+  const overall = { status: 'on-target', tone: 'ok', message: 'Creature is within expected ranges.', details: [] };
+
+  if (highCritical) {
+    overall.status = 'likely-too-strong';
+    overall.tone = 'critical';
+    overall.message = 'Likely too strong for its level.';
+    overall.details.push(`High metrics: ${describeSignals(highSignals)}.`);
+  } else if (lowCritical) {
+    overall.status = 'likely-too-weak';
+    overall.tone = 'critical';
+    overall.message = 'Likely too weak for its level.';
+    overall.details.push(`Low metrics: ${describeSignals(lowSignals)}.`);
+  } else if (highSignals.length >= 2) {
+    overall.status = 'likely-too-strong';
+    overall.tone = 'warning';
+    overall.message = 'Multiple metrics suggest this creature punches above its weight.';
+    overall.details.push(`Above baseline: ${describeSignals(highSignals)}.`);
+  } else if (lowSignals.length >= 2) {
+    overall.status = 'likely-too-weak';
+    overall.tone = 'warning';
+    overall.message = 'Multiple metrics suggest this creature falls below expectations.';
+    overall.details.push(`Below baseline: ${describeSignals(lowSignals)}.`);
+  } else if (highSignals.length === 1) {
+    overall.status = 'slightly-above';
+    overall.tone = 'warning';
+    overall.message = `Slightly above curve because ${describeSignals(highSignals)} is high.`;
+  } else if (lowSignals.length === 1) {
+    overall.status = 'slightly-below';
+    overall.tone = 'warning';
+    overall.message = `Slightly below curve because ${describeSignals(lowSignals)} is low.`;
+  }
+
+  if (attackCoverage.tone === 'warning') {
+    overall.details.push('Ensure the creature can pressure both PD and AD.');
+  }
+
+  return {
+    metrics,
+    featureCost,
+    attributeSummary,
+    attackCoverage,
+    overall,
+  };
+};

--- a/dc20-creature-creator/src/utils/featureCost.js
+++ b/dc20-creature-creator/src/utils/featureCost.js
@@ -1,0 +1,28 @@
+export const normalizeFeatureBalanceCost = (feature) => {
+  if (!feature || typeof feature !== 'object') {
+    return 1;
+  }
+
+  const rawValue = feature.balanceCost ?? feature.balance_cost ?? feature.balance_cost_value;
+
+  if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+    return rawValue >= 0 ? rawValue : 0;
+  }
+
+  if (typeof rawValue === 'string') {
+    const parsed = parseFloat(rawValue);
+    if (!Number.isNaN(parsed) && Number.isFinite(parsed)) {
+      return parsed >= 0 ? parsed : 0;
+    }
+  }
+
+  return 1;
+};
+
+export const sumFeatureBalanceCost = (features = []) => {
+  if (!Array.isArray(features)) {
+    return 0;
+  }
+
+  return features.reduce((total, feature) => total + normalizeFeatureBalanceCost(feature), 0);
+};

--- a/dc20-creature-creator/src/utils/featureEffects.js
+++ b/dc20-creature-creator/src/utils/featureEffects.js
@@ -25,6 +25,7 @@ const mapActionFeature = (feature) => ({
   baseDamageOverride: feature.baseDamageOverride,
   descriptionCore: feature.descriptionCore,
   originalFeatureId: feature.id || feature.originalFeatureId,
+  balanceCost: feature.balanceCost,
 });
 
 const mapEnhancementFeature = (feature) => ({
@@ -39,6 +40,7 @@ const mapEnhancementFeature = (feature) => ({
   conditionApplied: feature.conditionApplied,
   conditionDuration: feature.conditionDuration,
   originalFeatureId: feature.id || feature.originalFeatureId,
+  balanceCost: feature.balanceCost,
 });
 
 export const applyFeatureEffects = (stats, selectedFeatures = []) => {


### PR DESCRIPTION
## Summary
- add structured balance cost editing/display for features and seed data
- implement balance guideline utilities and tests for feature budgets and stat deviations
- mount a balance checklist beneath the stat block with styling and layout adjustments

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dcfee6021c83318aecef88f9d77001