### PR TITLE
Fix feature creation form data handling

### DIFF
--- a/dc20-creature-creator/src/components/FeatureCreationForm.jsx
+++ b/dc20-creature-creator/src/components/FeatureCreationForm.jsx
@@ -1,5 +1,4 @@
-// src/components/FeatureCreationForm.jsx
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import './FeatureCreationForm.css';
 
 const FEATURE_KINDS = [
@@ -9,28 +8,26 @@ const FEATURE_KINDS = [
   { id: 'reaction', label: 'Reaction' },
 ];
 
-
 const METHOD_OPTIONS = [
-    { id: '', label: 'Select Method...' },
-    { id: 'Melee Martial Attack', label: 'Melee Martial Attack' },
-    { id: 'Ranged Martial Attack', label: 'Ranged Martial Attack' },
-    { id: 'Melee Spell Attack', label: 'Melee Spell Attack' },
-    { id: 'Ranged Spell Attack', label: 'Ranged Spell Attack' },
-    { id: 'Buff', label: 'Buff' },
-    { id: 'Debuff', label: 'Debuff' },
-    { id: 'Healing', label: 'Healing' },
-    { id: 'Utility', label: 'Utility' },
+  { id: '', label: 'Select Method...' },
+  { id: 'Melee Martial Attack', label: 'Melee Martial Attack' },
+  { id: 'Ranged Martial Attack', label: 'Ranged Martial Attack' },
+  { id: 'Melee Spell Attack', label: 'Melee Spell Attack' },
+  { id: 'Ranged Spell Attack', label: 'Ranged Spell Attack' },
+  { id: 'Buff', label: 'Buff' },
+  { id: 'Debuff', label: 'Debuff' },
+  { id: 'Healing', label: 'Healing' },
+  { id: 'Utility', label: 'Utility' },
 ];
 
 const SAVE_ATTRIBUTES = [
-    { id: '', label: 'None' },
-    { id: 'Might', label: 'Might' },
-    { id: 'Agility', label: 'Agility' },
-    { id: 'Intelligence', label: 'Intelligence' },
-    { id: 'Charisma', label: 'Charisma' },
-    { id: 'Physical', label: 'Physical' },
-    { id: 'Mental', label: 'Mental' },
-
+  { id: '', label: 'None' },
+  { id: 'Might', label: 'Might' },
+  { id: 'Agility', label: 'Agility' },
+  { id: 'Intelligence', label: 'Intelligence' },
+  { id: 'Charisma', label: 'Charisma' },
+  { id: 'Physical', label: 'Physical' },
+  { id: 'Mental', label: 'Mental' },
 ];
 
 const DURATIONS = [
@@ -44,214 +41,237 @@ const DURATIONS = [
   { id: '1 minute (target saves each turn)', label: '1 Minute (target saves each turn)' },
 ];
 
-const parseNumberOrZero = (value) => {
+const parseNumberOrNull = (value) => {
+  if (value === '' || value === null || typeof value === 'undefined') {
+    return null;
+  }
   const parsed = parseInt(value, 10);
-  return Number.isNaN(parsed) ? 0 : parsed;
+  return Number.isNaN(parsed) ? null : parsed;
 };
 
-const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCreature }) => {
-    // --- Form State ---
-    const [name, setName] = useState('');
-    const [category, setCategory] = useState('feature');
-    const [description, setDescription] = useState('');
-    const [tags, setTags] = useState(''); // Comma-separated
-    const [costInputs, setCostInputs] = useState({ ap: '', mp: '', sp: '' });
-    const [balanceCost, setBalanceCost] = useState('1');
-    const [method, setMethod] = useState('Passive');
-    const [damageMod, setDamageMod] = useState('');
-    const [damageType, setDamageType] = useState('');
-    const [range, setRange] = useState('');
-    const [target, setTarget] = useState('');
-    const [defense, setDefense] = useState('');
-    const [duration, setDuration] = useState('');
-    const [saveAttribute, setSaveAttribute] = useState('');
-    const [saveEffect, setSaveEffect] = useState('');
-    const [conditionApplied, setConditionApplied] = useState('');
-    const [healingAmount, setHealingAmount] = useState('');
-    const [trigger, setTrigger] = useState('');
+const normalizeTags = (tagsInput) =>
+  tagsInput
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean)
+    .map((tag) => tag.toLowerCase());
 
-    // Reset fields when category changes to prevent carrying over irrelevant data
-    useEffect(() => {
-        setMethod(category === 'feature' ? 'Passive' : '');
-        setDamageMod('');
-        setDamageType('');
-        setRange('');
-        setTarget('');
-        setDefense('');
-        setHealingAmount('');
-        if (category === 'feature') {
-            setCostInputs({ ap: '', mp: '', sp: '' });
-            setSaveAttribute('');
-            setSaveEffect('');
-            setConditionApplied('');
-            setDuration('');
-        }
-        if (category !== 'reaction') {
-            setTrigger('');
-        }
-    }, [category]);
+const FeatureCreationForm = ({ onCancel, onAddFeature, onSaveFeatureToDB }) => {
+  const [name, setName] = useState('');
+  const [category, setCategory] = useState('feature');
+  const [summary, setSummary] = useState('');
+  const [tags, setTags] = useState('');
+  const [balanceCost, setBalanceCost] = useState('1');
+  const [costInputs, setCostInputs] = useState({ ap: '', mp: '', sp: '' });
+  const [method, setMethod] = useState('Passive');
+  const [range, setRange] = useState('');
+  const [target, setTarget] = useState('');
+  const [defense, setDefense] = useState('');
+  const [damageMod, setDamageMod] = useState('');
+  const [damageType, setDamageType] = useState('');
+  const [duration, setDuration] = useState('');
+  const [saveAttribute, setSaveAttribute] = useState('');
+  const [saveEffect, setSaveEffect] = useState('');
+  const [conditionApplied, setConditionApplied] = useState('');
+  const [healingAmount, setHealingAmount] = useState('');
+  const [trigger, setTrigger] = useState('');
 
-    const resetForm = () => {
-        setName('');
-        setCategory('feature');
-        setDescription('');
-        setTags('');
-        setCostInputs({ ap: '', mp: '', sp: '' });
-        setBalanceCost('1');
-        setMethod('Passive');
-        setDamageMod('');
-        setDamageType('');
-        setRange('');
-        setTarget('');
-        setDefense('');
-        setDuration('');
-        setSaveAttribute('');
-        setSaveEffect('');
-        setConditionApplied('');
-        setHealingAmount('');
+  useEffect(() => {
+    if (category === 'feature') {
+      setMethod('Passive');
+      setCostInputs({ ap: '', mp: '', sp: '' });
+      setRange('');
+      setTarget('');
+      setDefense('');
+      setDamageMod('');
+      setDamageType('');
+      setDuration('');
+      setSaveAttribute('');
+      setSaveEffect('');
+      setConditionApplied('');
+      setHealingAmount('');
+      setTrigger('');
+    } else {
+      setMethod('');
+      setDamageMod('');
+      setDamageType('');
+      setRange('');
+      setTarget('');
+      setDefense('');
+      setDuration('');
+      setSaveAttribute('');
+      setSaveEffect('');
+      setConditionApplied('');
+      setHealingAmount('');
+      if (category !== 'reaction') {
         setTrigger('');
-    };
-
-    const constructFeatureData = () => {
-        const numAP = parseInt(costInputs.ap, 10) || 0;
-        const numMP = parseInt(costInputs.mp, 10) || 0;
-        const numSP = parseInt(costInputs.sp, 10) || 0;
-        const parsedBalanceCost = parseFloat(balanceCost);
-        const numericBalanceCost = Number.isNaN(parsedBalanceCost) ? 1 : Math.max(0, parsedBalanceCost);
-
-        const costObject = {};
-        if (numAP > 0) costObject.ap = numAP;
-        if (numMP > 0) costObject.mp = numMP;
-        if (numSP > 0) costObject.sp = numSP;
-
-        const parsedRange = parseInt(range, 10);
-        const normalizedRange = Number.isNaN(parsedRange) ? undefined : Math.max(0, parsedRange);
-
-        const parsedDamageModifier = parseInt(damageMod, 10);
-        const normalizedDamageModifier = Number.isNaN(parsedDamageModifier) ? undefined : parsedDamageModifier;
-
-        const trimmedSummary = description.trim();
-        const trimmedTarget = target.trim();
-        const trimmedMethod = method.trim();
-        const normalizedMethodLower = trimmedMethod.toLowerCase();
-        const isHealingMethod = normalizedMethodLower.includes('healing');
-
-        const featureData = {
-            name: name.trim(),
-            category,
-            description: trimmedSummary,
-            summary: trimmedSummary,
-            tags: tags.split(',').map((t) => t.trim().toLowerCase()).filter(Boolean),
-            method: trimmedMethod || (category === 'feature' ? 'Passive' : null),
-            cost: Object.keys(costObject).length > 0 ? costObject : null,
-            duration: duration.trim() || null,
-            save: saveAttribute || null,
-            saveEffect: saveAttribute ? saveEffect.trim() : null,
-            conditionApplied: conditionApplied.trim() || null,
-            healingAmount: (category === 'action' && isHealingMethod) ? healingAmount.trim() : null,
-            balanceCost: numericBalanceCost,
-            trigger: category === 'reaction' ? (trigger.trim() || null) : null,
-        };
-
-        if (category === 'feature') {
-            featureData.effects = [];
-        }
-
-        if (category === 'action' || category === 'attack_enhancement' || category === 'reaction') {
-            if (trimmedTarget) {
-                featureData.target = trimmedTarget;
-            }
-            if (normalizedRange !== undefined) {
-                featureData.range = normalizedRange;
-            }
-        }
-
-        if ((category === 'action' || category === 'reaction') && (normalizedDamageModifier !== undefined || damageType.trim())) {
-            featureData.damage = {
-                modifier: normalizedDamageModifier || 0,
-                type: damageType.trim() || null,
-            };
-        }
-
-        if ((category === 'action' || category === 'reaction') && defense) {
-            featureData.defense = defense;
-        }
-
-        return featureData;
-    };
-
-    if (Object.keys(cost).length > 0 || kind === 'action' || kind === 'reaction' || kind === 'attack_enhancement') {
-      featureData.cost = cost;
-    }
-
-    const damageData = {
-      bonus: damageBonusNumber,
-      type: damageType.trim(),
-      base: null,
-    };
-
-    const isAttackLike = kind === 'action' && method && (method.includes('Attack') || method.includes('Spell'));
-    if (isAttackLike || (kind === 'attack_enhancement' && (damageBonus || damageType))) {
-      featureData.damage = damageData;
-    }
-
-    const saveData = {
-      attribute: saveAttribute,
-      dcMod: 0,
-      effect: saveEffect.trim(),
-    };
-
-    if (kind !== 'feature') {
-      featureData.method = method;
-      featureData.range = range.trim();
-      featureData.target = target.trim();
-      if (defense) {
-        featureData.defense = defense;
       }
-      featureData.save = saveData;
-      featureData.trigger = trigger.trim();
+    }
+  }, [category]);
+
+  const resetForm = () => {
+    setName('');
+    setCategory('feature');
+    setSummary('');
+    setTags('');
+    setBalanceCost('1');
+    setCostInputs({ ap: '', mp: '', sp: '' });
+    setMethod('Passive');
+    setRange('');
+    setTarget('');
+    setDefense('');
+    setDamageMod('');
+    setDamageType('');
+    setDuration('');
+    setSaveAttribute('');
+    setSaveEffect('');
+    setConditionApplied('');
+    setHealingAmount('');
+    setTrigger('');
+  };
+
+  const constructFeatureData = () => {
+    const trimmedName = name.trim();
+    const trimmedSummary = summary.trim();
+    const parsedBalance = parseFloat(balanceCost);
+    const normalizedBalance = Number.isNaN(parsedBalance) ? 1 : Math.max(parsedBalance, 0);
+
+    const cost = {};
+    ['ap', 'mp', 'sp'].forEach((key) => {
+      const parsed = parseNumberOrNull(costInputs[key]);
+      if (parsed !== null && parsed > 0) {
+        cost[key] = parsed;
+      }
+    });
+
+    const featureData = {
+      name: trimmedName,
+      category,
+      kind: category,
+      summary: trimmedSummary,
+      description: trimmedSummary,
+      balanceCost: normalizedBalance,
+      tags: normalizeTags(tags),
+    };
+
+    if (Object.keys(cost).length > 0) {
+      featureData.cost = cost;
+      featureData.costAP = cost.ap ?? 0;
+      featureData.costMP = cost.mp ?? 0;
+      featureData.costSP = cost.sp ?? 0;
     }
 
-    const methodLower = (method || '').toLowerCase();
-    const isAttackMethod = methodLower.includes('attack') || methodLower.includes('spell');
-    const isHealingMethod = methodLower.includes('healing');
-    const showCostFields = isAction || isAttackEnhancement || isReaction;
-    const showMethodField = category !== 'feature';
-    const showTargetingFields = isAction || isAttackEnhancement || isReaction;
-    const showAttackSpecificFields = (isAction || isReaction) && isAttackMethod;
-    const showDefenseField = (isAction || isReaction) && isAttackMethod;
-    const showHealingField = isAction && isHealingMethod;
-    const showSaveFields = isAction || isAttackEnhancement || isReaction;
-    const showDurationField = isAction || isAttackEnhancement || isReaction || conditionApplied;
+    if (category === 'feature') {
+      featureData.effects = [];
+    } else {
+      const trimmedMethod = method.trim();
+      const methodLower = trimmedMethod.toLowerCase();
+      const isHealingMethod = methodLower.includes('healing');
+      const rangeValue = parseNumberOrNull(range);
+      const trimmedTarget = target.trim();
+      const trimmedDefense = defense.trim();
+      const trimmedTrigger = trigger.trim();
+      const parsedDamageMod = parseNumberOrNull(damageMod);
+      const trimmedDamageType = damageType.trim();
+      const trimmedCondition = conditionApplied.trim();
+      const trimmedSaveEffect = saveEffect.trim();
+      const trimmedHealing = healingAmount.trim();
+
+      featureData.method = trimmedMethod || null;
+      featureData.actionType = trimmedMethod || null;
+
+      if (rangeValue !== null) {
+        featureData.range = rangeValue;
+        featureData.rangeValue = rangeValue;
+        featureData.rangeUnit = 'spaces';
+      }
+
+      if (trimmedTarget) {
+        featureData.target = trimmedTarget;
+      }
+
+      if (trimmedDefense) {
+        featureData.defense = trimmedDefense;
+        featureData.targetsDefense = trimmedDefense;
+      }
+
+      if (parsedDamageMod !== null || trimmedDamageType) {
+        featureData.damage = {};
+        if (parsedDamageMod !== null) {
+          featureData.damage.modifier = parsedDamageMod;
+          featureData.damageMod = parsedDamageMod;
+        }
+        if (trimmedDamageType) {
+          featureData.damage.type = trimmedDamageType;
+          featureData.damageType = trimmedDamageType;
+        }
+      }
+
+      if (saveAttribute) {
+        featureData.saveAttribute = saveAttribute;
+        featureData.save = {
+          attribute: saveAttribute,
+          effect: trimmedSaveEffect || null,
+          dcMod: 0,
+        };
+      }
+
+      if (trimmedSaveEffect) {
+        featureData.saveEffect = trimmedSaveEffect;
+      }
+
+      if (trimmedCondition) {
+        featureData.conditionApplied = trimmedCondition;
+      }
+
+      if (duration) {
+        featureData.conditionDuration = duration;
+        featureData.duration = duration;
+      }
+
+      if (isHealingMethod && trimmedHealing) {
+        featureData.healingAmount = trimmedHealing;
+      }
+
+      if (category === 'reaction' && trimmedTrigger) {
+        featureData.trigger = trimmedTrigger;
+      }
+    }
 
     return featureData;
   };
 
   const handleAdd = () => {
     const data = constructFeatureData();
-    onAddOnlyToCreature?.(data);
+    onAddFeature?.(data);
     resetForm();
   };
 
   const handleSaveAndAdd = async () => {
     const data = constructFeatureData();
-    const success = await onSaveAndAddToCreature?.(data);
+    const success = await onSaveFeatureToDB?.(data);
     if (success) {
       resetForm();
     }
   };
 
-  const isAction = kind === 'action';
-  const isAttackEnhancement = kind === 'attack_enhancement';
-  const isReaction = kind === 'reaction';
+  const isAction = category === 'action';
+  const isAttackEnhancement = category === 'attack_enhancement';
+  const isReaction = category === 'reaction';
+
+  const methodLower = (method || '').toLowerCase();
+  const isAttackMethod = methodLower.includes('attack') || methodLower.includes('spell');
+  const isHealingMethod = methodLower.includes('healing');
 
   const showCostFields = isAction || isAttackEnhancement || isReaction;
-  const showMethodField = isAction || isReaction;
-  const showAttackSpecificFields = isAction && method && (method.includes('Attack') || method.includes('Spell'));
-  const showHealingField = isAction && method === 'Healing';
+  const showMethodField = category !== 'feature';
+  const showTargetingFields = isAction || isAttackEnhancement || isReaction;
+  const showAttackSpecificFields = (isAction || isReaction) && isAttackMethod;
+  const showDefenseField = (isAction || isReaction) && isAttackMethod;
+  const showHealingField = isAction && isHealingMethod;
   const showSaveFields = isAction || isAttackEnhancement || isReaction;
-  const showDurationField = (isAction || isAttackEnhancement || isReaction) && !!conditionApplied;
-  const showTriggerField = isReaction || isAttackEnhancement;
+  const showDurationField = showSaveFields || !!conditionApplied;
+  const showTriggerField = isReaction;
 
   return (
     <div className="feature-creation-form">
@@ -274,8 +294,8 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
           <button
             key={option.id}
             type="button"
-            className={`category-button ${kind === option.id ? 'active' : ''}`}
-            onClick={() => setKind(option.id)}
+            className={`category-button ${category === option.id ? 'active' : ''}`}
+            onClick={() => setCategory(option.id)}
           >
             {option.label}
           </button>
@@ -314,15 +334,30 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
           <div className="cost-inputs">
             <div>
               <label>AP:</label>
-              <input type="number" min="0" value={costAP} onChange={(e) => setCostAP(e.target.value)} />
+              <input
+                type="number"
+                min="0"
+                value={costInputs.ap}
+                onChange={(e) => setCostInputs((prev) => ({ ...prev, ap: e.target.value }))}
+              />
             </div>
             <div>
               <label>MP:</label>
-              <input type="number" min="0" value={costMP} onChange={(e) => setCostMP(e.target.value)} />
+              <input
+                type="number"
+                min="0"
+                value={costInputs.mp}
+                onChange={(e) => setCostInputs((prev) => ({ ...prev, mp: e.target.value }))}
+              />
             </div>
             <div>
               <label>SP:</label>
-              <input type="number" min="0" value={costSP} onChange={(e) => setCostSP(e.target.value)} />
+              <input
+                type="number"
+                min="0"
+                value={costInputs.sp}
+                onChange={(e) => setCostInputs((prev) => ({ ...prev, sp: e.target.value }))}
+              />
             </div>
           </div>
         </fieldset>
@@ -334,39 +369,57 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
           <div className="form-group">
             <label>Method:</label>
             <select value={method} onChange={(e) => setMethod(e.target.value)}>
-              {ACTION_METHODS.map((option) => (
+              {METHOD_OPTIONS.map((option) => (
                 <option key={option.id} value={option.id}>
                   {option.label}
                 </option>
               ))}
             </select>
           </div>
-          <div className="form-group">
-            <label>Range:</label>
-            <input
-              type="text"
-              value={range}
-              onChange={(e) => setRange(e.target.value)}
-              placeholder="Melee, 5 spaces, Self"
-            />
-          </div>
-          <div className="form-group">
-            <label>Defense Targeted:</label>
-            <select value={defense} onChange={(e) => setDefense(e.target.value)}>
-              <option value="">Select...</option>
-              <option value="PD">PD</option>
-              <option value="AD">AD</option>
-            </select>
-          </div>
-          <div className="form-group">
-            <label>Target:</label>
-            <input
-              type="text"
-              value={target}
-              onChange={(e) => setTarget(e.target.value)}
-              placeholder="1 creature, Cone, All allies"
-            />
-          </div>
+          {showDefenseField && (
+            <div className="form-group">
+              <label>Defense:</label>
+              <select value={defense} onChange={(e) => setDefense(e.target.value)}>
+                <option value="">Select defense...</option>
+                <option value="PD">PD</option>
+                <option value="AD">AD</option>
+              </select>
+            </div>
+          )}
+          {showTargetingFields && (
+            <>
+              <div className="form-group">
+                <label>Target:</label>
+                <input
+                  type="text"
+                  value={target}
+                  onChange={(e) => setTarget(e.target.value)}
+                  placeholder="one creature, cone, all allies"
+                />
+              </div>
+              <div className="form-group">
+                <label>Range (spaces):</label>
+                <input
+                  type="number"
+                  min="0"
+                  value={range}
+                  onChange={(e) => setRange(e.target.value)}
+                  placeholder="Leave blank for default"
+                />
+              </div>
+            </>
+          )}
+          {showTriggerField && (
+            <div className="form-group">
+              <label>Trigger:</label>
+              <input
+                type="text"
+                value={trigger}
+                onChange={(e) => setTrigger(e.target.value)}
+                placeholder="When an ally within 6 spaces is hit..."
+              />
+            </div>
+          )}
         </fieldset>
       )}
 
@@ -377,8 +430,8 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
             <label>Damage Modifier:</label>
             <input
               type="number"
-              value={damageBonus}
-              onChange={(e) => setDamageBonus(e.target.value)}
+              value={damageMod}
+              onChange={(e) => setDamageMod(e.target.value)}
               placeholder="0, 1, -2"
             />
           </div>
@@ -409,13 +462,13 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
         </fieldset>
       )}
 
-      {(showSaveFields || showDurationField || showTriggerField) && (
+      {(showSaveFields || showDurationField) && (
         <fieldset className="form-section">
-          <legend>Effects & Duration</legend>
+          <legend>Effects &amp; Duration</legend>
           {showSaveFields && (
             <>
               <div className="form-group">
-                <label>Target Save Attribute:</label>
+                <label>Save Attribute:</label>
                 <select value={saveAttribute} onChange={(e) => setSaveAttribute(e.target.value)}>
                   {SAVE_ATTRIBUTES.map((option) => (
                     <option key={option.id} value={option.id}>
@@ -424,15 +477,17 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
                   ))}
                 </select>
               </div>
-              <div className="form-group">
-                <label>Effect on Save:</label>
-                <input
-                  type="text"
-                  value={saveEffect}
-                  onChange={(e) => setSaveEffect(e.target.value)}
-                  placeholder="half damage, negates"
-                />
-              </div>
+              {saveAttribute && (
+                <div className="form-group">
+                  <label>Effect on Save:</label>
+                  <input
+                    type="text"
+                    value={saveEffect}
+                    onChange={(e) => setSaveEffect(e.target.value)}
+                    placeholder="half damage, negates"
+                  />
+                </div>
+              )}
               <div className="form-group">
                 <label>Condition Applied:</label>
                 <input
@@ -454,153 +509,6 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
                   </option>
                 ))}
               </select>
-            </div>
-
-            {/* --- Cost Inputs --- */}
-            {showCostFields && (
-                <fieldset className="form-section">
-                    <legend>Costs</legend>
-                    <div className="cost-inputs">
-                        <div>
-                            <label>AP:</label>
-                            <input
-                                type="number"
-                                min="0"
-                                value={costInputs.ap}
-                                onChange={(e) => setCostInputs((prev) => ({ ...prev, ap: e.target.value }))}
-                            />
-                        </div>
-                        <div>
-                            <label>MP:</label>
-                            <input
-                                type="number"
-                                min="0"
-                                value={costInputs.mp}
-                                onChange={(e) => setCostInputs((prev) => ({ ...prev, mp: e.target.value }))}
-                            />
-                        </div>
-                        <div>
-                            <label>SP:</label>
-                            <input
-                                type="number"
-                                min="0"
-                                value={costInputs.sp}
-                                onChange={(e) => setCostInputs((prev) => ({ ...prev, sp: e.target.value }))}
-                            />
-                        </div>
-                    </div>
-                </fieldset>
-            )}
-
-            {/* --- Method, Targeting, and Reaction Details --- */}
-            {showMethodField && (
-                <fieldset className="form-section">
-                    <legend>Action Details</legend>
-                    <div className="form-group">
-                        <label>Method:</label>
-                        <select value={method} onChange={(e) => setMethod(e.target.value)}>
-                            {METHOD_OPTIONS.map((opt) => (
-                                <option key={opt.id} value={opt.id}>{opt.label}</option>
-                            ))}
-                        </select>
-                    </div>
-                    {showDefenseField && (
-                        <div className="form-group">
-                            <label>Defense:</label>
-                            <select value={defense} onChange={(e) => setDefense(e.target.value)}>
-                                <option value="">Select defense...</option>
-                                <option value="PD">PD</option>
-                                <option value="AD">AD</option>
-                            </select>
-                        </div>
-                    )}
-                    {showTargetingFields && (
-                        <>
-                            <div className="form-group">
-                                <label>Target:</label>
-                                <input
-                                    type="text"
-                                    value={target}
-                                    onChange={(e) => setTarget(e.target.value)}
-                                    placeholder="one creature, cone, all allies"
-                                />
-                            </div>
-                            <div className="form-group">
-                                <label>Range (spaces):</label>
-                                <input
-                                    type="number"
-                                    min="0"
-                                    value={range}
-                                    onChange={(e) => setRange(e.target.value)}
-                                    placeholder="Leave blank for default"
-                                />
-                            </div>
-                        </>
-                    )}
-                    {isReaction && (
-                        <div className="form-group">
-                            <label>Trigger:</label>
-                            <input
-                                type="text"
-                                value={trigger}
-                                onChange={(e) => setTrigger(e.target.value)}
-                                placeholder="When an ally within 6 spaces is hit..."
-                            />
-                        </div>
-                    )}
-                </fieldset>
-            )}
-
-            {/* --- Attack Specific --- */}
-            {showAttackSpecificFields && (
-                <fieldset className="form-section">
-                    <legend>Attack Properties</legend>
-                    <div className="form-group"><label>Damage Modifier:</label><input type="number" value={damageMod} onChange={e => setDamageMod(e.target.value)} placeholder="0, 1, -2" /></div>
-                    <div className="form-group"><label>Damage Type:</label><input type="text" value={damageType} onChange={e => setDamageType(e.target.value)} placeholder="physical, fire" /></div>
-                </fieldset>
-            )}
-
-            {/* --- Healing Specific --- */}
-            {showHealingField && (
-                <fieldset className="form-section">
-                    <legend>Healing Properties</legend>
-                    <div className="form-group"><label>Healing Amount:</label><input type="text" value={healingAmount} onChange={e => setHealingAmount(e.target.value)} placeholder="5, MIG Mod" /></div>
-                </fieldset>
-            )}
-
-            {/* --- Save, Condition, Duration --- */}
-            {(showSaveFields || showDurationField) && (
-                <fieldset className="form-section">
-                    <legend>Effects & Duration</legend>
-                    {showSaveFields && (
-                        <>
-                            <div className="form-group"><label>Save Attribute:</label>
-                                <select value={saveAttribute} onChange={e => setSaveAttribute(e.target.value)}>
-                                    {SAVE_ATTRIBUTES.map(sa => <option key={sa.id} value={sa.id}>{sa.label}</option>)}
-                                </select>
-                            </div>
-                            {saveAttribute && <div className="form-group"><label>Effect on Save:</label><input type="text" value={saveEffect} onChange={e => setSaveEffect(e.target.value)} placeholder="half damage, negates" /></div>}
-                            <div className="form-group"><label>Condition Applied:</label><input type="text" value={conditionApplied} onChange={e => setConditionApplied(e.target.value)} placeholder="Stunned, Prone" /></div>
-                        </>
-                    )}
-                    {showDurationField && (
-                        <div className="form-group"><label>Duration:</label>
-                            <select value={duration} onChange={e => setDuration(e.target.value)}>
-                                {DURATIONS.map(d => <option key={d.id} value={d.id}>{d.label}</option>)}
-                            </select>
-                        </div>
-                    )}
-                </fieldset>
-            )}
-
-            <div className="form-group">
-              <label>Trigger:</label>
-              <input
-                type="text"
-                value={trigger}
-                onChange={(e) => setTrigger(e.target.value)}
-                placeholder="When hit, After you attack, Reaction to..."
-              />
             </div>
           )}
         </fieldset>
@@ -624,7 +532,7 @@ const FeatureCreationForm = ({ onCancel, onAddOnlyToCreature, onSaveAndAddToCrea
           Add to Creature
         </button>
         <button type="button" onClick={handleSaveAndAdd} className="button-save">
-          Save & Add to Creature
+          Save &amp; Add to Creature
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- rebuild the custom feature form to align its props with the input panel
- normalize created feature data so cost, targeting, damage, and save fields match downstream expectations
- reset category-specific inputs properly when switching between feature types

## Testing
- npm test *(fails: existing suite already reports unrelated failures)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc706530483319b621de3f36ed969