### PR TITLE
Improve attack enhancement descriptions

### DIFF
--- a/dc20-creature-creator/src/utils/presentationFormatter.js
+++ b/dc20-creature-creator/src/utils/presentationFormatter.js
@@ -72,24 +72,53 @@ const extractDamageInfo = (attack, extra) => {
 const extractSaveInfo = (extra) => {
   if (!extra) return null;
   if (extra.saveText) {
-    return { text: extra.saveText, dc: extra.calculatedSaveDC };
+    return {
+      text: extra.saveText,
+      dc: extra.calculatedSaveDC,
+    };
   }
   if (typeof extra.save === 'string') {
-    return { text: extra.save, dc: extra.calculatedSaveDC };
+    return {
+      text: extra.save,
+      dc: extra.calculatedSaveDC,
+    };
   }
   if (extra.save && typeof extra.save === 'object') {
-    const text = extra.save.text || extra.save.summary || extra.save.description || '';
-    return { text, dc: extra.calculatedSaveDC };
+    const attribute =
+      extra.save.attribute || extra.save.ability || extra.save.stat || extra.save.attributeName;
+    const effect =
+      extra.save.effect ||
+      extra.save.onFail ||
+      extra.save.onFailure ||
+      extra.save.failure ||
+      extra.save.failureEffect;
+    const text =
+      extra.save.text ||
+      extra.save.summary ||
+      extra.save.description ||
+      (attribute ? `${attribute} save` : '');
+    return {
+      text,
+      dc: extra.calculatedSaveDC,
+      attribute,
+      effect,
+    };
   }
   if (extra.saveAttribute) {
-    let saveText = `Target makes a ${extra.saveAttribute} save`;
+    const attribute = extra.saveAttribute;
+    let effectText = '';
     if (extra.conditionApplied) {
-      saveText += ` or becomes ${extra.conditionApplied}`;
+      effectText = `On a failure, the target becomes ${extra.conditionApplied}`;
       if (extra.conditionDuration) {
-        saveText += ` (${extra.conditionDuration.replace('your', 'its')})`;
+        effectText += ` (${extra.conditionDuration.replace('your', 'its')})`;
       }
     }
-    return { text: saveText, dc: extra.calculatedSaveDC };
+    return {
+      text: `Target makes a ${attribute} save`,
+      dc: extra.calculatedSaveDC,
+      attribute,
+      effect: effectText,
+    };
   }
   return null;
 };
@@ -119,6 +148,12 @@ const createAttackDescription = (attack, extra) => {
   if (saveInfo && saveInfo.text) {
     const dcText = typeof saveInfo.dc === 'number' ? ` (DC ${saveInfo.dc})` : '';
     parts.push(`${saveInfo.text}${dcText}.`);
+    if (saveInfo.effect) {
+      const trimmedEffect = saveInfo.effect.trim();
+      if (trimmedEffect.length > 0) {
+        parts.push(/[.!?]$/.test(trimmedEffect) ? trimmedEffect : `${trimmedEffect}.`);
+      }
+    }
   } else if (extra?.conditionApplied) {
     let conditionText = `Applies ${extra.conditionApplied}`;
     if (extra.conditionDuration) {
@@ -152,6 +187,75 @@ const formatAttackDisplay = (attack, extras = {}) => ({
   details: createAttackDescription(attack, extras),
   originalFeatureId: attack.originalFeatureId || null,
 });
+
+const ensureSentence = (value) => {
+  const trimmed = (value || '').trim();
+  if (!trimmed) return '';
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+};
+
+const createEnhancementDescription = (enh = {}) => {
+  if (!enh) return '';
+
+  const parts = [];
+  const summaryText = typeof enh.summary === 'string' ? enh.summary.trim() : '';
+  if (summaryText) {
+    parts.push(ensureSentence(summaryText));
+  }
+
+  const {
+    summary: _omitSummary,
+    save: _omitSave,
+    saveText: _omitSaveText,
+    saveAttribute: _omitSaveAttribute,
+    conditionApplied: _omitConditionApplied,
+    conditionDuration: _omitConditionDuration,
+    ...restEnh
+  } = enh;
+  const sanitizedExtras = { ...restEnh };
+  const sanitizedAttack = {
+    damage: enh.damage,
+    defense: enh.defense,
+    target: enh.target,
+    range: enh.range,
+  };
+
+  const additionalDescription = createAttackDescription(sanitizedAttack, sanitizedExtras).trim();
+  if (additionalDescription) {
+    parts.push(additionalDescription);
+  }
+
+  const saveInfo = extractSaveInfo(enh);
+  if (saveInfo && (saveInfo.text || saveInfo.attribute || saveInfo.effect || typeof saveInfo.dc === 'number')) {
+    const saveParts = [];
+    const basePieces = [];
+    if (typeof saveInfo.dc === 'number') {
+      basePieces.push(`DC ${saveInfo.dc}`);
+    }
+    const normalizedText = saveInfo.attribute
+      ? `${saveInfo.attribute} save`
+      : (saveInfo.text || '').trim();
+    if (normalizedText) {
+      basePieces.push(normalizedText);
+    }
+    const baseSentence = basePieces.join(' ').trim();
+    if (baseSentence) {
+      saveParts.push(ensureSentence(baseSentence));
+    } else if ((saveInfo.text || '').trim()) {
+      saveParts.push(ensureSentence(saveInfo.text));
+    }
+    if (saveInfo.effect) {
+      saveParts.push(ensureSentence(saveInfo.effect));
+    }
+    parts.push(saveParts.filter(Boolean).join(' '));
+  }
+
+  return parts
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
 
 export const formatForPresentation = (raw, derived) => {
   const display = {
@@ -216,13 +320,7 @@ export const formatForPresentation = (raw, derived) => {
 
   display.Combat.AttackEnhancements = (derived.attackEnhancements || []).map((enh) => ({
     name: `${enh.name} (${enh.displayCost || 'Special'})`,
-    details: createAttackDescription({
-      damage: enh.damage,
-      defense: enh.defense,
-      target: enh.target,
-      range: enh.range,
-      summary: enh.summary,
-    }, enh),
+    details: createEnhancementDescription(enh),
     originalFeatureId: enh.originalFeatureId,
   }));
 


### PR DESCRIPTION
## Summary
- extend save parsing to retain attribute and failure effect information for display
- add a dedicated enhancement description builder so attack enhancements highlight their summary and save text

## Testing
- npm test *(fails: existing balance guideline expectations in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e1548c4fd0833192ecb14c6d43beac