### PR TITLE
Refine attack enhancement save display and editing

### DIFF
--- a/dc20-creature-creator/src/components/StatBlockPanel.css
+++ b/dc20-creature-creator/src/components/StatBlockPanel.css
@@ -596,6 +596,30 @@
     padding-left: 18px;
 }
 
+.enhancement-text-line {
+    display: inline;
+    line-height: 1.4;
+}
+
+.enhancement-text-line .editable-span,
+.enhancement-text-line .editable-input {
+    display: inline;
+    width: auto;
+    margin-left: 0;
+    padding: 1px 2px;
+}
+
+.enhancement-summary-field.editable-span,
+.enhancement-summary-field.editable-input {
+    font-weight: 500;
+}
+
+.enhancement-inline-field.editable-span,
+.enhancement-inline-field.editable-input {
+    min-width: 24px;
+    text-align: left;
+}
+
 .hover-remove-button:hover {
     color: #ff0000;
 }

--- a/dc20-creature-creator/src/components/StatBlockPanel.jsx
+++ b/dc20-creature-creator/src/components/StatBlockPanel.jsx
@@ -371,28 +371,74 @@ const StatBlockPanel = forwardRef(
             {display.Combat.AttackEnhancements && display.Combat.AttackEnhancements.length > 0 && (
                 <div className="sb-sub-section attack-enhancements-section">
                     <h4 className="sb-sub-section-title"><GiUpgrade className="sb-section-icon" />Attack Enhancements</h4>
-                    {display.Combat.AttackEnhancements.map((enh, index) => (
-                        <div key={enh.originalFeatureId || `enhance-${index}`} className="sb-list-item enhancement-item">
-                            <p>
-                                <EditableField
-                                    value={enh.name}
-                                    onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_name_set`, val)}
-                                    fieldName={`Combat_AttackEnhancements_${index}_name_set`}
-                                    fieldType="text"
-                                    className="editable-name-field"
-                                />
-                                <br />
-                                <EditableField
-                                    value={enh.details}
-                                    onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_details_set`, val)}
-                                    fieldName={`Combat_AttackEnhancements_${index}_details_set`}
-                                    fieldType="text"
-                                    className="editable-description-field"
-                                />
-                            </p>
-                            {enh.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(findOriginalItemForRemove(enh, "AttackEnhancements"))} />}
-                        </div>
-                    ))}
+                    {display.Combat.AttackEnhancements.map((enh, index) => {
+                        const rawEnhancement = finalRaw.AttackEnhancements?.[index];
+                        const hasDisplaySaveDC = enh.saveDC !== '' && enh.saveDC !== null && typeof enh.saveDC !== 'undefined';
+                        const showSaveEditors = Boolean(
+                            rawEnhancement?.save ||
+                            rawEnhancement?.saveAttribute ||
+                            enh.saveAttribute ||
+                            enh.saveEffect ||
+                            hasDisplaySaveDC
+                        );
+
+                        const attributeValueRaw = enh.saveAttribute ?? '';
+                        const attributeHasValue =
+                            (typeof attributeValueRaw === 'string' && attributeValueRaw.trim().length > 0) ||
+                            (typeof attributeValueRaw !== 'string' && attributeValueRaw !== '' && attributeValueRaw !== null && typeof attributeValueRaw !== 'undefined');
+
+                        return (
+                            <div key={enh.originalFeatureId || `enhance-${index}`} className="sb-list-item enhancement-item">
+                                <p>
+                                    <EditableField
+                                        value={enh.name}
+                                        onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_name_set`, val)}
+                                        fieldName={`Combat_AttackEnhancements_${index}_name_set`}
+                                        fieldType="text"
+                                        className="editable-name-field"
+                                    />
+                                    <br />
+                                    <span className="enhancement-text-line">
+                                        <EditableField
+                                            value={enh.summary || enh.details || ''}
+                                            onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_summary_set`, val)}
+                                            fieldName={`Combat_AttackEnhancements_${index}_summary_set`}
+                                            fieldType="text"
+                                            className="editable-description-field enhancement-summary-field"
+                                        />
+                                        {showSaveEditors && (
+                                            <>
+                                                {' '}The target makes a DC{' '}
+                                                <EditableField
+                                                    value={enh.saveDC ?? ''}
+                                                    onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_save_dc_set`, val)}
+                                                    fieldName={`Combat_AttackEnhancements_${index}_save_dc_set`}
+                                                    fieldType="number"
+                                                    className="enhancement-inline-field enhancement-save-dc"
+                                                />{' '}
+                                                <EditableField
+                                                    value={enh.saveAttribute ?? ''}
+                                                    onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_save_attribute_set`, val)}
+                                                    fieldName={`Combat_AttackEnhancements_${index}_save_attribute_set`}
+                                                    fieldType="text"
+                                                    className="enhancement-inline-field enhancement-save-attribute"
+                                                />
+                                                {attributeHasValue ? ' save.' : 'save.'}{' '}
+                                                <EditableField
+                                                    value={enh.saveEffect ?? ''}
+                                                    onSave={(f, val) => handleSave(`Combat_AttackEnhancements_${index}_save_effect_set`, val)}
+                                                    fieldName={`Combat_AttackEnhancements_${index}_save_effect_set`}
+                                                    fieldType="text"
+                                                    className="enhancement-inline-field enhancement-save-effect"
+                                                />
+                                            </>
+                                        )}
+                                    </span>
+                                </p>
+                                {enh.originalFeatureId && <HoverRemoveButton onClick={() => onRemoveFeature(findOriginalItemForRemove(enh, "AttackEnhancements"))} />}
+                            </div>
+                        );
+                    })}
                 </div>
             )}
 

--- a/dc20-creature-creator/src/utils/presentationFormatter.js
+++ b/dc20-creature-creator/src/utils/presentationFormatter.js
@@ -72,24 +72,53 @@ const extractDamageInfo = (attack, extra) => {
 const extractSaveInfo = (extra) => {
   if (!extra) return null;
   if (extra.saveText) {
-    return { text: extra.saveText, dc: extra.calculatedSaveDC };
+    return {
+      text: extra.saveText,
+      dc: extra.calculatedSaveDC,
+    };
   }
   if (typeof extra.save === 'string') {
-    return { text: extra.save, dc: extra.calculatedSaveDC };
+    return {
+      text: extra.save,
+      dc: extra.calculatedSaveDC,
+    };
   }
   if (extra.save && typeof extra.save === 'object') {
-    const text = extra.save.text || extra.save.summary || extra.save.description || '';
-    return { text, dc: extra.calculatedSaveDC };
+    const attribute =
+      extra.save.attribute || extra.save.ability || extra.save.stat || extra.save.attributeName;
+    const effect =
+      extra.save.effect ||
+      extra.save.onFail ||
+      extra.save.onFailure ||
+      extra.save.failure ||
+      extra.save.failureEffect;
+    const text =
+      extra.save.text ||
+      extra.save.summary ||
+      extra.save.description ||
+      (attribute ? `${attribute} save` : '');
+    return {
+      text,
+      dc: extra.calculatedSaveDC,
+      attribute,
+      effect,
+    };
   }
   if (extra.saveAttribute) {
-    let saveText = `Target makes a ${extra.saveAttribute} save`;
+    const attribute = extra.saveAttribute;
+    let effectText = '';
     if (extra.conditionApplied) {
-      saveText += ` or becomes ${extra.conditionApplied}`;
+      effectText = `On a failure, the target becomes ${extra.conditionApplied}`;
       if (extra.conditionDuration) {
-        saveText += ` (${extra.conditionDuration.replace('your', 'its')})`;
+        effectText += ` (${extra.conditionDuration.replace('your', 'its')})`;
       }
     }
-    return { text: saveText, dc: extra.calculatedSaveDC };
+    return {
+      text: `Target makes a ${attribute} save`,
+      dc: extra.calculatedSaveDC,
+      attribute,
+      effect: effectText,
+    };
   }
   return null;
 };
@@ -119,6 +148,12 @@ const createAttackDescription = (attack, extra) => {
   if (saveInfo && saveInfo.text) {
     const dcText = typeof saveInfo.dc === 'number' ? ` (DC ${saveInfo.dc})` : '';
     parts.push(`${saveInfo.text}${dcText}.`);
+    if (saveInfo.effect) {
+      const trimmedEffect = saveInfo.effect.trim();
+      if (trimmedEffect.length > 0) {
+        parts.push(/[.!?]$/.test(trimmedEffect) ? trimmedEffect : `${trimmedEffect}.`);
+      }
+    }
   } else if (extra?.conditionApplied) {
     let conditionText = `Applies ${extra.conditionApplied}`;
     if (extra.conditionDuration) {
@@ -152,6 +187,74 @@ const formatAttackDisplay = (attack, extras = {}) => ({
   details: createAttackDescription(attack, extras),
   originalFeatureId: attack.originalFeatureId || null,
 });
+
+const ensureSentence = (value) => {
+  const trimmed = (value || '').trim();
+  if (!trimmed) return '';
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+};
+
+const normalizeFailureClause = (value = '') => {
+  if (!value) return '';
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  return trimmed.replace(/\bOn\s+(?:an?\s+)?failure\b/i, (match) =>
+    match.charAt(0) === 'O' ? 'On failure' : 'on failure',
+  );
+};
+
+const createEnhancementDescription = (enh = {}) => {
+  if (!enh) return '';
+
+  const parts = [];
+  const summaryText = typeof enh.summary === 'string' ? enh.summary.trim() : '';
+  if (summaryText) {
+    parts.push(ensureSentence(summaryText));
+  }
+
+  const descriptionText =
+    typeof enh.description === 'string' ? enh.description.trim() : '';
+  if (descriptionText && descriptionText !== summaryText) {
+    parts.push(ensureSentence(descriptionText));
+  }
+
+  const saveInfo = extractSaveInfo(enh);
+  if (saveInfo && (saveInfo.text || saveInfo.attribute || saveInfo.effect || typeof saveInfo.dc === 'number')) {
+    const structuredPieces = [];
+    if (typeof saveInfo.dc === 'number') {
+      structuredPieces.push(`DC ${saveInfo.dc}`);
+    }
+    if (saveInfo.attribute) {
+      structuredPieces.push(saveInfo.attribute);
+    }
+
+    let saveClause = structuredPieces.length > 0 ? `${structuredPieces.join(' ')} save` : '';
+    const rawSaveText = (saveInfo.text || '').trim();
+    if (!saveClause && rawSaveText) {
+      saveClause = rawSaveText.replace(/\.$/, '');
+    }
+
+    if (saveClause) {
+      const normalizedClause = saveClause.startsWith('The target')
+        ? saveClause
+        : `The target makes a ${saveClause}`;
+      parts.push(ensureSentence(normalizedClause));
+    }
+
+    if (saveInfo.effect) {
+      const normalizedEffect = normalizeFailureClause(saveInfo.effect);
+      if (normalizedEffect) {
+        parts.push(ensureSentence(normalizedEffect));
+      }
+    }
+  }
+
+  return parts
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
 
 export const formatForPresentation = (raw, derived) => {
   const display = {
@@ -214,17 +317,27 @@ export const formatForPresentation = (raw, derived) => {
     }
   });
 
-  display.Combat.AttackEnhancements = (derived.attackEnhancements || []).map((enh) => ({
-    name: `${enh.name} (${enh.displayCost || 'Special'})`,
-    details: createAttackDescription({
-      damage: enh.damage,
-      defense: enh.defense,
-      target: enh.target,
-      range: enh.range,
-      summary: enh.summary,
-    }, enh),
-    originalFeatureId: enh.originalFeatureId,
-  }));
+  display.Combat.AttackEnhancements = (derived.attackEnhancements || []).map((enh) => {
+    const saveInfo = extractSaveInfo(enh) || {};
+    const normalizedSaveEffect = normalizeFailureClause(
+      saveInfo.effect || enh.save?.effect || enh.saveEffect,
+    );
+
+    return {
+      name: `${enh.name} (${enh.displayCost || 'Special'})`,
+      details: createEnhancementDescription(enh),
+      originalFeatureId: enh.originalFeatureId,
+      summary: enh.summary || '',
+      saveAttribute: saveInfo.attribute || enh.saveAttribute || enh.save?.attribute || '',
+      saveDC:
+        typeof saveInfo.dc === 'number'
+          ? saveInfo.dc
+          : typeof enh.calculatedSaveDC === 'number'
+          ? enh.calculatedSaveDC
+          : enh.save?.dc || '',
+      saveEffect: normalizedSaveEffect || '',
+    };
+  });
 
   display.Reactions = (derived.reactions || []).map((reaction) => ({
     name: `${reaction.name} (${reaction.displayCost || 'Reaction'})`,


### PR DESCRIPTION
## Summary
- build attack enhancement descriptions with summary and targeted save clauses so the rendered text matches desired phrasing
- surface separate editable fields for summary, save DC, save attribute, and save effect directly in the inline enhancement text
- adjust stat block panel styling to support inline editing controls for the enhanced save sentence

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1548c4fd0833192ecb14c6d43beac