### PR TITLE
Fix action damage and range normalization

### DIFF
--- a/dc20-creature-creator/src/domain/creatureBuilder.js
+++ b/dc20-creature-creator/src/domain/creatureBuilder.js
@@ -95,13 +95,151 @@ const toCostObject = (action = {}) => {
   };
 };
 
+const toNumeric = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+};
+
+const normalizeDamage = (action = {}) => {
+  const rawDamage = action.damage;
+  const resolvedType =
+    (rawDamage && typeof rawDamage === 'object' && rawDamage.type) || action.damageType || '';
+
+  if (!rawDamage && !action.damageMod && !action.damageBonus) {
+    return { modifier: 0, type: resolvedType };
+  }
+
+  if (typeof rawDamage === 'number') {
+    return {
+      base: rawDamage,
+      modifier: toNumeric(action.damageMod) || 0,
+      total: rawDamage + (toNumeric(action.damageMod) || 0),
+      type: resolvedType,
+    };
+  }
+
+  const modifier =
+    toNumeric(rawDamage?.modifier) ??
+    toNumeric(rawDamage?.bonus) ??
+    toNumeric(action.damageMod) ??
+    toNumeric(action.damageBonus) ??
+    0;
+
+  const base =
+    toNumeric(rawDamage?.base) ??
+    (typeof rawDamage?.total === 'number' && Number.isFinite(modifier)
+      ? rawDamage.total - modifier
+      : undefined);
+
+  const total =
+    toNumeric(rawDamage?.total) ??
+    (typeof base === 'number'
+      ? Math.ceil(base + (Number.isFinite(modifier) ? modifier : 0))
+      : undefined);
+
+  return {
+    ...(rawDamage && typeof rawDamage === 'object' ? { ...rawDamage } : {}),
+    base,
+    modifier,
+    bonus:
+      rawDamage && typeof rawDamage === 'object' && typeof rawDamage.bonus !== 'undefined'
+        ? rawDamage.bonus
+        : undefined,
+    total,
+    type: resolvedType,
+  };
+};
+
+const normalizeRange = (action = {}) => {
+  const explicitValue = toNumeric(action.rangeValue);
+  const explicitUnit = action.rangeUnit;
+  const rawRange = action.range ?? action.rangeText;
+
+  if (rawRange && typeof rawRange === 'object') {
+    const text = rawRange.text || `${rawRange.value || explicitValue || ''} ${rawRange.unit || explicitUnit || ''}`.trim();
+    return {
+      range: { ...rawRange, text },
+      rangeValue: toNumeric(rawRange.value) ?? explicitValue,
+      rangeUnit: rawRange.unit || explicitUnit || undefined,
+    };
+  }
+
+  if (typeof rawRange === 'number') {
+    const inferredUnit = explicitUnit || (rawRange === 1 ? 'space' : 'spaces');
+    const text = `${rawRange} ${inferredUnit}`.trim();
+    return {
+      range: { value: rawRange, unit: inferredUnit, text },
+      rangeValue: rawRange,
+      rangeUnit: inferredUnit || undefined,
+    };
+  }
+
+  if (typeof rawRange === 'string' && rawRange.trim().length > 0) {
+    const text = rawRange.trim();
+    const match = text.match(/(-?\d+(?:\.\d+)?)/);
+    const value = match ? Number(match[1]) : explicitValue;
+    const rawUnitCandidate = match ? text.slice(match.index + match[1].length).trim() : '';
+    const inferredUnit =
+      rawUnitCandidate ||
+      explicitUnit ||
+      (typeof value === 'number' && Number.isFinite(value)
+        ? value === 1
+          ? 'space'
+          : 'spaces'
+        : undefined);
+    const normalizedText =
+      rawUnitCandidate || !value
+        ? text
+        : `${value} ${inferredUnit}`.trim();
+    return {
+      range: {
+        text: normalizedText,
+        ...(typeof value === 'number' && Number.isFinite(value) ? { value } : {}),
+        ...(inferredUnit ? { unit: inferredUnit.replace(/s$/, '') } : {}),
+      },
+      rangeValue: typeof value === 'number' && Number.isFinite(value) ? value : explicitValue,
+      rangeUnit:
+        inferredUnit && typeof inferredUnit === 'string'
+          ? inferredUnit.replace(/s$/, '')
+          : explicitUnit || undefined,
+    };
+  }
+
+  if (typeof explicitValue === 'number') {
+    const unit = explicitUnit || (explicitValue === 1 ? 'space' : 'spaces');
+    const text = `${explicitValue} ${unit}`.trim();
+    return {
+      range: { value: explicitValue, unit, text },
+      rangeValue: explicitValue,
+      rangeUnit: unit || undefined,
+    };
+  }
+
+  return { range: rawRange || '', rangeValue: explicitValue, rangeUnit: explicitUnit || undefined };
+};
+
+const normalizeTarget = (action = {}) => {
+  if (action.target && typeof action.target === 'object') return action.target;
+  const textCandidate =
+    (typeof action.target === 'string' && action.target.trim()) ||
+    (typeof action.targetDescription === 'string' && action.targetDescription.trim()) ||
+    (typeof action.targets === 'string' && action.targets.trim()) ||
+    '';
+  return textCandidate ? { text: textCandidate } : action.target;
+};
+
 const mapDisplayAction = (action = {}, source = 'default') => {
   const cost = toCostObject(action);
-  const target = action.target?.text || action.target || action.targetDescription || action.targets || '';
-  const range =
-    (action.range && typeof action.range === 'object'
-      ? action.range.text || `${action.range.value || ''} ${action.range.unit || ''}`.trim()
-      : action.range) || '';
+  const normalizedDamage = normalizeDamage(action);
+  const normalizedRange = normalizeRange(action);
+  const target = normalizeTarget(action);
+
+  const saveDcMod = toNumeric(action.save?.dcMod);
+  const fallbackSaveDcMod = toNumeric(action.saveDCMod);
 
   return {
     name: action.name || '',
@@ -109,12 +247,15 @@ const mapDisplayAction = (action = {}, source = 'default') => {
     costAP: cost.ap,
     costMP: cost.mp,
     costSP: cost.sp,
-    damage: action.damage || { modifier: action.damageMod || 0, type: action.damageType },
-    damageMod: action.damage?.modifier || action.damageMod || 0,
+    damage: normalizedDamage,
+    damageMod: toNumeric(normalizedDamage?.modifier) || 0,
     save: action.save || null,
-    saveDCMod: action.save?.dcMod || action.saveDCMod || 0,
-    range,
+    saveDCMod: saveDcMod ?? fallbackSaveDcMod ?? 0,
+    range: normalizedRange.range,
+    rangeValue: normalizedRange.rangeValue,
+    rangeUnit: normalizedRange.rangeUnit,
     target,
+    targetDescription: target?.text || action.targetDescription || '',
     defense: action.defense || action.targetsDefense || '',
     actionType: action.actionType || action.type || '',
     description: action.summary || action.descriptionCore || action.description || '',

--- a/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
+++ b/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
@@ -62,8 +62,54 @@ describe('calculateCreatureStats', () => {
     expect(displayAttack).toBeDefined();
     expect(displayAttack.details).toContain('4 fire damage vs PD.');
     expect(displayAttack.details).toContain('Target 1 creature within 1 space.');
-    expect(displayAttack.details).toContain('Mig save (DC 16).');
+    expect(displayAttack.details).toContain('Might (DC 16).');
 
+  });
+
+  it('includes base damage and range in default melee attack descriptions', () => {
+    const inputs = {
+      level: 1,
+      power: 'normal',
+      role: 'none',
+      type: 'beast',
+      size: 'medium',
+      creatureName: 'Default Attack Check'
+    };
+
+    const result = calculateCreatureStats(inputs, [], {});
+    const defaultAttack = result.display.Combat.Attacks[0];
+
+    expect(defaultAttack).toBeDefined();
+    expect(defaultAttack.details).toContain('physical damage vs PD');
+    expect(defaultAttack.details).toContain('Target 1 creature within 1 space.');
+  });
+
+  it('treats damage bonuses as modifiers when calculating action damage', () => {
+    const inputs = {
+      level: 1,
+      power: 'normal',
+      role: 'none',
+      type: 'beast',
+      size: 'medium',
+      creatureName: 'Bonus Damage Test'
+    };
+
+    const powerStrike = {
+      name: 'Power Strike',
+      category: 'action',
+      method: 'Melee Martial Attack',
+      cost: { ap: 2 },
+      damage: { bonus: 1, type: 'physical' },
+      defense: 'PD',
+      range: 'melee',
+      target: '1 creature'
+    };
+
+    const result = calculateCreatureStats(inputs, [powerStrike], {});
+    const strike = result.display.Combat.Attacks.find((a) => a.name.startsWith('Power Strike'));
+
+    expect(strike).toBeDefined();
+    expect(strike.details).toContain('3 physical damage vs PD');
   });
 
   it('applies overrides to default attacks', () => {

--- a/dc20-creature-creator/src/utils/balanceGuidelines.js
+++ b/dc20-creature-creator/src/utils/balanceGuidelines.js
@@ -61,7 +61,7 @@ const halfStep = (value) => Math.round(value * 2) / 2;
 
 export const getFeatureCostBudget = (level = 0, power = 'normal') => {
   const normalizedLevel = Number.isFinite(level) ? Math.max(0, level) : 0;
-  const baseBudget = normalizedLevel + 2; // Normal power expectation scales directly with level
+  const baseBudget = Math.ceil(normalizedLevel / 2);
   const lowerBand = Math.max(0, baseBudget - 1);
   const upperBand = baseBudget + 1;
 

--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -56,7 +56,10 @@ const extractSaveText = (action = {}) => {
 const enhanceActionData = (rawStats, actions = []) =>
   actions.map((action) => {
     const category = action.category || 'action';
-    const damageModifier = toNumberOr(action.damage?.modifier, toNumberOr(action.damageMod, 0));
+    const damageModifier = toNumberOr(
+      action.damage?.modifier,
+      toNumberOr(action.damage?.bonus, toNumberOr(action.damageMod, 0)),
+    );
     const damageBaseOverride =
       typeof action.damage?.base === 'number'
         ? action.damage.base
@@ -105,7 +108,10 @@ const enhanceActionData = (rawStats, actions = []) =>
 const enhanceEnhancements = (rawStats, enhancements = []) =>
   enhancements.map((enh) => {
     const category = enh.category || 'attack_enhancement';
-    const damageModifier = toNumberOr(enh.damage?.modifier, toNumberOr(enh.damageMod, 0));
+    const damageModifier = toNumberOr(
+      enh.damage?.modifier,
+      toNumberOr(enh.damage?.bonus, toNumberOr(enh.damageMod, 0)),
+    );
     const damageBaseOverride =
       typeof enh.damage?.base === 'number'
         ? enh.damage.base

--- a/dc20-creature-creator/src/utils/featureEffects.js
+++ b/dc20-creature-creator/src/utils/featureEffects.js
@@ -124,6 +124,16 @@ const normalizeRange = (feature) => {
     };
   }
 
+  if (typeof raw === 'number' && Number.isFinite(raw)) {
+    const unit = feature.rangeUnit || (raw === 1 ? 'space' : 'spaces');
+    const text = `${raw} ${unit}`.trim();
+    return {
+      value: raw,
+      unit: unit || undefined,
+      text,
+    };
+  }
+
   if (raw && typeof raw === 'object') {
     const text =
       raw.text ||
@@ -169,7 +179,7 @@ const normalizeTarget = (feature) => {
 const normalizeDamage = (feature) => {
   const raw = feature.damage && typeof feature.damage === 'object' ? { ...feature.damage } : {};
   if (typeof raw.modifier !== 'number') {
-    raw.modifier = numberOr(feature.damageMod, 0);
+    raw.modifier = numberOr(raw.bonus, numberOr(feature.damageMod, 0));
   }
   if (!raw.type && feature.damageType) {
     raw.type = feature.damageType;
@@ -240,7 +250,8 @@ const mapActionFeature = (feature) => {
     id: feature.id,
     name: feature.name,
     category: feature.category,
-    actionType: feature.actionType,
+    actionType: feature.actionType || feature.method,
+    method: feature.method,
     cost,
     costAP: cost.ap,
     costMP: cost.mp,


### PR DESCRIPTION
## Summary
- normalize action damage handling to preserve base damage, support damage bonuses, and keep range data for display editing
- adjust feature action normalization to carry method metadata, infer numeric ranges, and treat bonus values as modifiers
- update balance budget calculation and add regression tests covering default attacks and damage bonuses

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e1925128c483319914c1ec2488a1df