### PR TITLE
Prevent duplicate attack details in inline editor

### DIFF
--- a/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
+++ b/dc20-creature-creator/src/components/ActionInlineDisplay.jsx
@@ -20,7 +20,8 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
         rangeValue,
         rangeUnit,
         summary,
-        details = '',
+        details,
+        description,
     } = action;
 
     const resolvedDamageType = damage?.type || damageType || 'damage';
@@ -68,6 +69,47 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
         if (rangeValue) return `${rangeValue} ${rangeUnit || ''}`.trim();
         return '';
     })();
+
+    const normalizedSummary =
+        typeof summary === 'string' && summary.trim().length > 0 ? summary.trim() : summary;
+    const resolvedDetailsText = (() => {
+        if (typeof details === 'string' && details.trim().length > 0) {
+            return details.trim();
+        }
+        if (typeof description === 'string' && description.trim().length > 0) {
+            return description.trim();
+        }
+        return '';
+    })();
+    const normalizedDetails = resolvedDetailsText || undefined;
+    const shouldRenderSummary = Boolean(normalizedSummary);
+    const shouldRenderDetails = Boolean(normalizedDetails);
+
+    const hasNumericDamageMod = typeof action.damageMod === 'number' && Number.isFinite(action.damageMod);
+    const hasNumericDamageBonus = typeof action.damageBonus === 'number' && Number.isFinite(action.damageBonus);
+    const hasDamageDetails = (() => {
+        if (typeof damage === 'number') return true;
+        if (damage && typeof damage === 'object') {
+            const numericKeys = ['base', 'total', 'modifier', 'bonus'];
+            const hasMeaningfulNumeric = numericKeys.some((key) => {
+                const value = damage[key];
+                return typeof value === 'number' && Number.isFinite(value) && value !== 0;
+            });
+            if (hasMeaningfulNumeric) {
+                return true;
+            }
+            return false;
+        }
+        if (hasNumericDamageMod) {
+            return Boolean(action.isAttack || (damage && typeof damage === 'object') || typeof damage === 'number');
+        }
+        if (hasNumericDamageBonus) {
+            return Boolean(action.isAttack || (damage && typeof damage === 'object') || typeof damage === 'number');
+        }
+        return false;
+    })();
+    const shouldRenderDamage =
+        typeof resolvedDamageAmount === 'number' || action.isAttack || hasDamageDetails;
 
     const targetDisplay = (() => {
         if (typeof target === 'string') return target;
@@ -171,45 +213,50 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
             <strong>{renderCost()}</strong>
             ):
             {' '}
-            {typeof resolvedDamageAmount === 'number' ? (
-                <EditableField
-                    value={resolvedDamageAmount}
-                    onSave={(f, val) => handleDamageTotalSave(val)}
-                    fieldType="number"
-                    className="editable-number-field"
-                />
-            ) : (
-                'damage '
+            {shouldRenderDamage && (
+                <>
+                    {typeof resolvedDamageAmount === 'number' ? (
+                        <EditableField
+                            value={resolvedDamageAmount}
+                            onSave={(f, val) => handleDamageTotalSave(val)}
+                            fieldType="number"
+                            className="editable-number-field"
+                        />
+                    ) : (
+                        'damage '
+                    )}
+                    <EditableField
+                        value={resolvedDamageType}
+                        onSave={(f, val) => handleSave('damageType', val)}
+                        fieldType="text"
+                        className="editable-description-field"
+                    />{' '}
+                    damage vs{' '}
+                    {isEditingDefense ? (
+                        <select
+                            value={defense}
+                            onChange={(e) => {
+                                handleSave('defense', e.target.value);
+                                setIsEditingDefense(false);
+                            }}
+                            onBlur={() => setIsEditingDefense(false)}
+                            className="editable-select"
+                        >
+                            <option value="PD">PD</option>
+                            <option value="AD">AD</option>
+                        </select>
+                    ) : (
+                        <span
+                            onDoubleClick={() => setIsEditingDefense(true)}
+                            className="editable-select-span"
+                        >
+                            {resolvedDefense}
+                        </span>
+                    )}
+                    .{' '}
+                </>
             )}
-            <EditableField
-                value={resolvedDamageType}
-                onSave={(f, val) => handleSave('damageType', val)}
-                fieldType="text"
-                className="editable-description-field"
-            />{' '}
-            damage vs{' '}
-            {isEditingDefense ? (
-                <select
-                    value={defense}
-                    onChange={(e) => {
-                        handleSave('defense', e.target.value);
-                        setIsEditingDefense(false);
-                    }}
-                    onBlur={() => setIsEditingDefense(false)}
-                    className="editable-select"
-                >
-                    <option value="PD">PD</option>
-                    <option value="AD">AD</option>
-                </select>
-            ) : (
-                <span
-                    onDoubleClick={() => setIsEditingDefense(true)}
-                    className="editable-select-span"
-                >
-                    {resolvedDefense}
-                </span>
-            )}
-            . Target{' '}
+            Target{' '}
             <EditableField
                 value={targetDisplay}
                 onSave={(f, val) => handleSave('target.text', val)}
@@ -223,15 +270,28 @@ const ActionInlineDisplay = ({ action, onSaveField }) => {
                 fieldType="text"
                 className="editable-description-field"
             />.
-            {details && (
+            {(shouldRenderSummary || shouldRenderDetails) && (
                 <>
                     <br />
-                    <EditableField
-                        value={summary || ''}
-                        onSave={(f, val) => handleSave('summary', val)}
-                        fieldType="text"
-                        className="editable-description-field"
-                    />
+                    {shouldRenderSummary && (
+                        <EditableField
+                            value={summary || ''}
+                            onSave={(f, val) => handleSave('summary', val)}
+                            fieldType="text"
+                            className="editable-description-field"
+                        />
+                    )}
+                    {shouldRenderDetails && (
+                        <>
+                            {shouldRenderSummary && <br />}
+                            <EditableField
+                                value={resolvedDetailsText}
+                                onSave={(f, val) => handleSave('details', val)}
+                                fieldType="text"
+                                className="editable-description-field"
+                            />
+                        </>
+                    )}
                 </>
             )}
         </p>

--- a/dc20-creature-creator/src/components/StatBlockPanel.jsx
+++ b/dc20-creature-creator/src/components/StatBlockPanel.jsx
@@ -133,7 +133,7 @@ const StatBlockPanel = forwardRef(
 
         const normalizeTarget = (source = {}) => source.target || source.targetDescription || source.targets || '';
 
-        const normalizeSummary = (source = {}) => source.summary || source.details || source.descriptionCore || source.description || '';
+        const normalizeSummary = (source = {}) => source.summary || source.descriptionCore || source.description || '';
 
         const normalizeDamage = (source = {}) => {
             const rawDamage = source.damage;
@@ -250,6 +250,26 @@ const StatBlockPanel = forwardRef(
                 key: `generated-default-attack-${index}`,
                 action: assembleAction(action),
             }));
+
+    const resolveInlineDetails = (rawAction = {}, displayAction = {}) => {
+        const candidates = [rawAction.details, rawAction.description, rawAction.descriptionCore];
+        for (const candidate of candidates) {
+            if (typeof candidate === 'string' && candidate.trim().length > 0) {
+                return candidate.trim();
+            }
+        }
+
+        const displayDetails =
+            typeof displayAction.details === 'string' && displayAction.details.trim().length > 0
+                ? displayAction.details.trim()
+                : '';
+
+        const actionType = rawAction.actionType || rawAction.method || '';
+        const typeLower = actionType.toLowerCase();
+        const isAttackType = typeLower.includes('attack') || typeLower.includes('spell');
+
+        return isAttackType ? '' : displayDetails;
+    };
 
     const getEditableNumericValue = (statString) => {
         if (typeof statString === 'string') {
@@ -480,7 +500,7 @@ const StatBlockPanel = forwardRef(
                                         ...act,
                                         damage: derivedAction?.calculatedDamage ?? act.damage,
                                         calculatedDamage: derivedAction?.calculatedDamage,
-                                        details: displayAction?.details,
+                                        details: resolveInlineDetails(act, displayAction || {}),
                                     }}
                                     onSaveField={(field, val) => handleActionFieldSave(idx, field, val)}
                                 />
@@ -497,7 +517,7 @@ const StatBlockPanel = forwardRef(
                                 <ActionInlineDisplay
                                     action={{
                                         ...act,
-                                        details: displayAction?.details,
+                                        details: resolveInlineDetails(act, displayAction || {}),
                                         damage: derivedAction?.calculatedDamage ?? act.damage,
                                         calculatedDamage: derivedAction?.calculatedDamage,
                                     }}

--- a/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
+++ b/dc20-creature-creator/src/utils/__tests__/calculateStats.test.js
@@ -112,6 +112,40 @@ describe('calculateCreatureStats', () => {
     expect(strike.details).toContain('3 physical damage vs PD');
   });
 
+  it('does not assign damage to non-attack utility actions', () => {
+    const inputs = {
+      level: 1,
+      power: 'normal',
+      role: 'none',
+      type: 'beast',
+      size: 'medium',
+      creatureName: 'Support Test'
+    };
+
+    const rally = {
+      id: 'action_command_rally',
+      name: 'Command: Rally',
+      category: 'action',
+      method: 'Buff',
+      summary: 'You bark orders that steel your allies, granting them a Help Dice (d8) until the end of their next turn.',
+      cost: { ap: 2 },
+      range: '5 Spaces',
+      target: 'up to 2 allies you can see'
+    };
+
+    const result = calculateCreatureStats(inputs, [rally], {});
+    const [derivedAction] = result.derived.combatActions;
+    const [displayAction] = result.display.Combat.OtherActions;
+
+    expect(derivedAction).toBeDefined();
+    expect(derivedAction.isAttack).toBe(false);
+    expect(derivedAction.damage == null).toBe(true);
+    expect(derivedAction.calculatedDamage).toBeUndefined();
+    if (displayAction?.details) {
+      expect(displayAction.details).not.toMatch(/damage/i);
+    }
+  });
+
   it('applies overrides to default attacks', () => {
     const inputs = {
       level: 1,

--- a/dc20-creature-creator/src/utils/calculateStats.jsx
+++ b/dc20-creature-creator/src/utils/calculateStats.jsx
@@ -56,23 +56,40 @@ const extractSaveText = (action = {}) => {
 const enhanceActionData = (rawStats, actions = []) =>
   actions.map((action) => {
     const category = action.category || 'action';
+    const originalDamage = action.damage;
     const damageModifier = toNumberOr(
-      action.damage?.modifier,
-      toNumberOr(action.damage?.bonus, toNumberOr(action.damageMod, 0)),
+      originalDamage?.modifier,
+      toNumberOr(originalDamage?.bonus, toNumberOr(action.damageMod, 0)),
     );
     const damageBaseOverride =
-      typeof action.damage?.base === 'number'
-        ? action.damage.base
+      typeof originalDamage?.base === 'number'
+        ? originalDamage.base
         : typeof action.baseDamageOverride === 'number'
         ? action.baseDamageOverride
         : null;
 
+    const hasExplicitDamage =
+      typeof originalDamage === 'number' ||
+      (originalDamage && typeof originalDamage === 'object');
+    const hasMeaningfulDamageMod =
+      typeof action.damageMod === 'number' &&
+      (hasExplicitDamage || typeof damageBaseOverride === 'number');
+    const shouldCalculateDamage =
+      isAttackAction(action) ||
+      hasExplicitDamage ||
+      typeof damageBaseOverride === 'number' ||
+      hasMeaningfulDamageMod ||
+      typeof action.damageBonus === 'number';
+
     const calculatedDamage = (() => {
+      if (!shouldCalculateDamage) {
+        return undefined;
+      }
       if (typeof damageBaseOverride === 'number') {
         return damageBaseOverride + damageModifier;
       }
       if (!isAttackAction(action)) {
-        return 0;
+        return undefined;
       }
       return rawStats.Damage + damageModifier;
     })();
@@ -80,22 +97,36 @@ const enhanceActionData = (rawStats, actions = []) =>
     const calculatedSaveDC = rawStats.SaveDC + extractSaveDcMod(action);
     const displayCost = buildCostDisplay(action.cost, action, category);
     const saveText = extractSaveText(action);
-    const totalDamage = Math.ceil(calculatedDamage);
+    const totalDamage =
+      typeof calculatedDamage === 'number' && Number.isFinite(calculatedDamage)
+        ? Math.ceil(calculatedDamage)
+        : undefined;
 
-    return {
-      ...action,
-      category,
-      damage: {
-        ...(action.damage && typeof action.damage === 'object' ? action.damage : {}),
+    const normalizedDamage = (() => {
+      if (!shouldCalculateDamage) {
+        if (hasExplicitDamage && typeof originalDamage === 'object') {
+          return { ...originalDamage };
+        }
+        return hasExplicitDamage ? originalDamage : undefined;
+      }
+
+      return {
+        ...(typeof originalDamage === 'object' ? originalDamage : {}),
         modifier: damageModifier,
         base:
           typeof damageBaseOverride === 'number'
             ? damageBaseOverride
-            : action.damage?.base,
+            : originalDamage?.base,
         total: totalDamage,
-        type: action.damage?.type || action.damageType,
-      },
-      damageType: action.damage?.type || action.damageType,
+        type: originalDamage?.type || action.damageType,
+      };
+    })();
+
+    return {
+      ...action,
+      category,
+      ...(normalizedDamage != null && { damage: normalizedDamage }),
+      damageType: normalizedDamage?.type || action.damageType,
       calculatedDamage: totalDamage,
       calculatedSaveDC,
       displayCost,

--- a/dc20-creature-creator/src/utils/featureEffects.js
+++ b/dc20-creature-creator/src/utils/featureEffects.js
@@ -177,9 +177,30 @@ const normalizeTarget = (feature) => {
 };
 
 const normalizeDamage = (feature) => {
+  const hasExplicitDamage = (() => {
+    if (typeof feature.damage === 'number') return true;
+    if (feature.damage && typeof feature.damage === 'object') {
+      return Object.keys(feature.damage).length > 0;
+    }
+    if (typeof feature.damageMod === 'number') return true;
+    if (typeof feature.damageBonus === 'number') return true;
+    if (typeof feature.baseDamageOverride === 'number') return true;
+    return false;
+  })();
+
+  if (!hasExplicitDamage) {
+    return null;
+  }
+
   const raw = feature.damage && typeof feature.damage === 'object' ? { ...feature.damage } : {};
   if (typeof raw.modifier !== 'number') {
-    raw.modifier = numberOr(raw.bonus, numberOr(feature.damageMod, 0));
+    if (typeof raw.bonus === 'number') {
+      raw.modifier = raw.bonus;
+    } else if (typeof feature.damageMod === 'number') {
+      raw.modifier = feature.damageMod;
+    } else if (typeof feature.damageBonus === 'number') {
+      raw.modifier = feature.damageBonus;
+    }
   }
   if (!raw.type && feature.damageType) {
     raw.type = feature.damageType;


### PR DESCRIPTION
## Summary
- prefer author-provided descriptions when rendering action details inline so attacks no longer repeat generated damage text
- avoid falling back to computed detail strings when normalizing action summaries and only surface derived details for non-attack actions

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e1a23febb48331a63b1cca5244655f