### PR TITLE
Normalize save attribute labels

### DIFF
--- a/dc20-creature-creator/src/uploadFeatures.mjs
+++ b/dc20-creature-creator/src/uploadFeatures.mjs
@@ -191,7 +191,7 @@ const creatureFeatures = [
     defense: 'AD',
     range: 'self',
     target: 'creatures in a 3-space cone',
-    save: { attribute: 'Agi', effect: 'On failure, target is Slowed 1 until end of its next turn' },
+    save: { attribute: 'Agility', effect: 'On failure, target is Slowed 1 until end of its next turn' },
     tags: ['spell', 'cold', 'aoe', 'control'],
   },
   {
@@ -229,7 +229,7 @@ const creatureFeatures = [
     cost: { ap: 1, mp: 1 },
     range: "10 Spaces",
     target: '1 creature you can see',
-    save: { attribute: 'Cha', effect: 'On failure, the creature drops a held weapon' },
+    save: { attribute: 'Charisma', effect: 'On failure, the creature drops a held weapon' },
     tags: ['spell', 'control', 'mental'],
   },
   {
@@ -319,7 +319,7 @@ const creatureFeatures = [
     kind: 'attack_enhancement',
     summary: 'You channel necrotic energy that may stun the target.',
     cost: { ap: 1 },
-    save: { attribute: 'Cha', effect: 'On failure, target is Stunned(1) until end of its next turn' },
+    save: { attribute: 'Charisma', effect: 'On failure, target is Stunned(1) until end of its next turn' },
     tags: ['undead', 'control', "enhancement"],
   },
   {
@@ -345,7 +345,7 @@ const creatureFeatures = [
     kind: 'attack_enhancement',
     summary: 'Frost clings to the target, slowing them if they fail an Agility save.',
     cost: { mp: 1 },
-    save: { attribute: 'Agi', effect: 'On failure, the target is Slowed until end of its next turn' },
+    save: { attribute: 'Agility', effect: 'On failure, the target is Slowed until end of its next turn' },
     tags: ['cold', 'control'],
   },
   {
@@ -354,7 +354,7 @@ const creatureFeatures = [
     kind: 'attack_enhancement',
     summary: 'You draw your foe’s focus with brutal bravado, forcing them to target you on a failed Charisma save.',
     cost: { ap: 1 },
-    save: { attribute: 'Cha', effect: 'On failure, the target is Taunted until start of your next turn' },
+    save: { attribute: 'Charisma', effect: 'On failure, the target is Taunted until start of your next turn' },
     tags: ['defender', 'taunt'],
   },
 
@@ -377,11 +377,11 @@ const creatureFeatures = [
     name: 'Mythic Roar',
     kind: 'apex_action',
     method: 'Spell',
-    summary: 'Each enemy within 3 spaces must succeed on a Cha save or become frightened for 1 round.',
+    summary: 'Each enemy within 3 spaces must succeed on a Charisma save or become frightened for 1 round.',
     cost: { ap: 2 },
     range: "3 Spaces",
     target: 'all enemies within range',
-    save: { attribute: 'Cha', effect: 'On failure, the enemy is Frightened for 1 round' },
+    save: { attribute: 'Charisma', effect: 'On failure, the enemy is Frightened for 1 round' },
     tags: ['apex'],
   },
 ];


### PR DESCRIPTION
## Summary
- replace shorthand save attribute values in `uploadFeatures.mjs` with the canonical attribute names
- align the Mythic Roar description to use the Charisma save terminology

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e21a0c13e48331bc585d1d8c6505a0