### PR TITLE
Add enhancement tags to missing attack upgrades

### DIFF
--- a/dc20-creature-creator/src/uploadFeatures.mjs
+++ b/dc20-creature-creator/src/uploadFeatures.mjs
@@ -346,7 +346,7 @@ const creatureFeatures = [
     summary: 'Frost clings to the target, slowing them if they fail an Agility save.',
     cost: { mp: 1 },
     save: { attribute: 'Agi', effect: 'On failure, the target is Slowed until end of its next turn' },
-    tags: ['cold', 'control'],
+    tags: ['cold', 'control', 'enhancement'],
   },
   {
     id: 'enhance_domineering_taunt',
@@ -355,7 +355,7 @@ const creatureFeatures = [
     summary: 'You draw your foe’s focus with brutal bravado, forcing them to target you on a failed Charisma save.',
     cost: { ap: 1 },
     save: { attribute: 'Cha', effect: 'On failure, the target is Taunted until start of your next turn' },
-    tags: ['defender', 'taunt'],
+    tags: ['defender', 'taunt', 'enhancement'],
   },
 
   // --- APEX ACTIONS ---


### PR DESCRIPTION
## Summary
- add the `enhancement` tag to the Freezing Mark and Domineering Taunt attack enhancements so they filter correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e21a47c3d88331aeb41743924bb002