### PR TITLE
Fix gravitic pulse range wording

### DIFF
--- a/dc20-creature-creator/src/uploadFeatures.mjs
+++ b/dc20-creature-creator/src/uploadFeatures.mjs
@@ -295,7 +295,7 @@ const creatureFeatures = [
     cost: { ap: 2, mp: 2 },
     damage: { bonus: 0, type: 'force' },
     defense: 'AD',
-    range: "8 Space",
+    range: "8 Spaces",
     target: 'creatures in a 3-space sphere',
     save: { attribute: 'Physical', effect: 'On failure, pulled up to 2 spaces toward the center; heavy hits also knock prone' },
     tags: ['controller', 'zone', 'force'],


### PR DESCRIPTION
## Summary
- correct the Gravitic Pulse action range description to use "8 Spaces"
- confirm nearby action entries use consistent pluralization for range values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e21a62844883318e26bd4b9ee39588