### PR TITLE
Remove unused Firebase auth import from upload script

### DIFF
--- a/dc20-creature-creator/src/uploadFeatures.mjs
+++ b/dc20-creature-creator/src/uploadFeatures.mjs
@@ -1,6 +1,5 @@
 import { initializeApp } from "firebase/app";
 import { getFirestore, collection, doc, setDoc } from "firebase/firestore";
-import { getAuth } from "firebase/auth";
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
@@ -18,7 +17,6 @@ const app = initializeApp(firebaseConfig);
 
 // Initialize Cloud Firestore and get a reference to the service
 const db = getFirestore(app);
-const auth = getAuth(app);
 
 const creatureFeatures = [
   // --- PASSIVE FEATURES ---


### PR DESCRIPTION
## Summary
- remove the unused Firebase Auth import from the uploadFeatures script
- rely solely on Firestore initialization for feature uploads

## Testing
- node src/uploadFeatures.mjs *(hangs while attempting to reach Firestore; aborted in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e21a6c1158833192cd3e7374d0f960